### PR TITLE
Sort output of expand_path

### DIFF
--- a/src/lgdo/lgdo_utils.py
+++ b/src/lgdo/lgdo_utils.py
@@ -180,7 +180,7 @@ def expand_path(
     _path = expand_vars(path, substitute)
 
     # then expand wildcards
-    paths = glob.glob(os.path.expanduser(_path))
+    paths = sorted(glob.glob(os.path.expanduser(_path)))
 
     if base_path is not None and base_path != "":
         paths = [os.path.relpath(p, base_path) for p in paths]


### PR DESCRIPTION
Change `expand_path` in `lgdo_utils` to sort the output of a wildcard expression. glob returns an unsorted list, which causes problems if you are trying to read from multiple directories in parallel (e.g., if you want to get the raw and dsp and hit tables using a wildcard expression). Note that the data loader was not using wildcard expressions, so neither this bug nor bug fix affect it.