### PR TITLE
Invert order of variable substitutions in `lgdo_utils.expand_vars()`

### DIFF
--- a/src/lgdo/lgdo_utils.py
+++ b/src/lgdo/lgdo_utils.py
@@ -135,15 +135,15 @@ def expand_vars(expr: str, substitute: dict[str, str] = None) -> str:
         string expression, which may include (environment) variables prefixed by
         ``$``.
     substitute
-        use this dictionary to substitute variables. Environment variables take
-        precedence.
+        use this dictionary to substitute variables. Takes precedence over
+        environment variables.
     """
     if substitute is None:
         substitute = {}
 
-    # expand env variables first
-    # then try using provided mapping
-    return string.Template(os.path.expandvars(expr)).safe_substitute(substitute)
+    # use provided mapping
+    # then expand env variables
+    return os.path.expandvars(string.Template(expr).safe_substitute(substitute))
 
 
 def expand_path(


### PR DESCRIPTION
There is otherwise no way to override existing environment variables (e.g. `$_` expands to the path to the python executable in a Conda environment!).

Bug report: https://github.com/legend-exp/pygama/issues/513