### PR TITLE
Allow for in-place reading + decompression of `ArrayOfEqualSizedArrays` if object buffer is provided

### DIFF
--- a/src/lgdo/compression/generic.py
+++ b/src/lgdo/compression/generic.py
@@ -40,6 +40,7 @@ def encode(
 
 def decode(
     obj: lgdo.VectorOfEncodedVectors | lgdo.ArrayOfEncodedEqualSizedArrays,
+    out_buf: lgdo.ArrayOfEqualSizedArrays = None,
 ) -> lgdo.VectorOfVectors | lgdo.ArrayOfEqualsizedArrays:
     """Decode encoded LGDOs.
 
@@ -51,6 +52,9 @@ def decode(
     ----------
     obj
         LGDO array type.
+    out_buf
+        pre-allocated LGDO for the decoded signals. See documentation of
+        wrapped encoders for limitations.
     """
     if "codec" not in obj.attrs:
         raise RuntimeError(
@@ -61,9 +65,11 @@ def decode(
     log.debug(f"decoding {repr(obj)} with {codec}")
 
     if _is_codec(codec, radware.RadwareSigcompress):
-        return radware.decode(obj, shift=int(obj.attrs.get("codec_shift", 0)))
+        return radware.decode(
+            obj, sig_out=out_buf, shift=int(obj.attrs.get("codec_shift", 0))
+        )
     elif _is_codec(codec, varlen.ULEB128ZigZagDiff):
-        return varlen.decode(obj)
+        return varlen.decode(obj, sig_out=out_buf)
     else:
         raise ValueError(f"'{codec}' not supported")
 

--- a/src/lgdo/compression/radware.py
+++ b/src/lgdo/compression/radware.py
@@ -251,6 +251,12 @@ def decode(
                 dtype=int32,
                 attrs=sig_in.getattrs(),
             )
+        else:
+            if not (
+                isinstance(sig_out, lgdo.ArrayOfEqualSizedArrays)
+                and sig_out.nda.shape == (len(sig_in), sig_in.decoded_size.value)
+            ):
+                raise ValueError("sig_out is of the wrong format")
 
         siglen = np.empty(len(sig_in), dtype=uint32)
         # save original encoded vector lengths

--- a/src/lgdo/compression/radware.py
+++ b/src/lgdo/compression/radware.py
@@ -251,12 +251,6 @@ def decode(
                 dtype=int32,
                 attrs=sig_in.getattrs(),
             )
-        else:
-            if not (
-                isinstance(sig_out, lgdo.ArrayOfEqualSizedArrays)
-                and sig_out.nda.shape == (len(sig_in), sig_in.decoded_size.value)
-            ):
-                raise ValueError("sig_out is of the wrong format")
 
         siglen = np.empty(len(sig_in), dtype=uint32)
         # save original encoded vector lengths
@@ -269,7 +263,7 @@ def decode(
         # can now decode on the 2D matrix together with number of bytes to read per row
         _, siglen = decode(
             (sig_in.encoded_data.to_aoesa(preserve_dtype=True).nda, nbytes),
-            sig_out.nda,
+            sig_out if isinstance(sig_out, np.ndarray) else sig_out.nda,
             shift=shift,
         )
 

--- a/src/lgdo/compression/radware.py
+++ b/src/lgdo/compression/radware.py
@@ -120,7 +120,7 @@ def encode(
         return sig_out, nbytes
 
     elif isinstance(sig_in, lgdo.VectorOfVectors):
-        if sig_out:
+        if sig_out is not None:
             log.warning(
                 "a pre-allocated VectorOfEncodedVectors was given "
                 "to hold an encoded ArrayOfEqualSizedArrays. "
@@ -143,7 +143,7 @@ def encode(
         return sig_out
 
     elif isinstance(sig_in, lgdo.ArrayOfEqualSizedArrays):
-        if sig_out:
+        if sig_out is not None:
             log.warning(
                 "a pre-allocated ArrayOfEncodedEqualSizedArrays was given "
                 "to hold an encoded ArrayOfEqualSizedArrays. "
@@ -243,7 +243,7 @@ def decode(
         return sig_out, siglen
 
     elif isinstance(sig_in, lgdo.ArrayOfEncodedEqualSizedArrays):
-        if not sig_out:
+        if sig_out is None:
             # initialize output structure with decoded_size
             sig_out = lgdo.ArrayOfEqualSizedArrays(
                 dims=(1, 1),

--- a/src/lgdo/compression/varlen.py
+++ b/src/lgdo/compression/varlen.py
@@ -94,7 +94,7 @@ def encode(
         return sig_out, nbytes
 
     elif isinstance(sig_in, lgdo.VectorOfVectors):
-        if sig_out:
+        if sig_out is not None:
             log.warning(
                 "a pre-allocated VectorOfEncodedVectors was given "
                 "to hold an encoded ArrayOfEqualSizedArrays. "
@@ -208,7 +208,7 @@ def decode(
         return sig_out, siglen
 
     elif isinstance(sig_in, lgdo.ArrayOfEncodedEqualSizedArrays):
-        if not sig_out:
+        if sig_out is None:
             # initialize output structure with decoded_size
             sig_out = lgdo.ArrayOfEqualSizedArrays(
                 dims=(1, 1),

--- a/tests/compression/test_radware_sigcompress.py
+++ b/tests/compression/test_radware_sigcompress.py
@@ -167,6 +167,13 @@ def test_aoesa(wftable):
     for wf1, wf2 in zip(dec_aoesa, wftable.values):
         assert np.array_equal(wf1, wf2)
 
+    # test using pre-allocated decoded array
+    sig_out = ArrayOfEqualSizedArrays(
+        shape=wftable.values.nda.shape, dtype=wftable.values.dtype
+    )
+    decode(enc_vov, sig_out=sig_out, shift=shift)
+    assert wftable.values == sig_out
+
 
 def test_performance(lgnd_test_data):
     store = LH5Store()

--- a/tests/compression/test_radware_sigcompress.py
+++ b/tests/compression/test_radware_sigcompress.py
@@ -107,8 +107,9 @@ def test_wrapper(wftable):
 
     enc_wfs = np.zeros(s[:-1] + (2 * s[-1],), dtype="ubyte")
     enclen = np.empty(s[0], dtype="uint32")
+    _shift = np.full(s[0], shift, dtype="int32")
 
-    _radware_sigcompress_encode(wfs, enc_wfs, shift, enclen, _mask)
+    _radware_sigcompress_encode(wfs, enc_wfs, _shift, enclen, _mask)
 
     # test if the wrapper gives the same result
     w_enc_wfs, w_enclen = encode(wfs, shift=shift)

--- a/tests/test_lh5_store.py
+++ b/tests/test_lh5_store.py
@@ -340,23 +340,27 @@ def test_read_wftable_encoded(lh5_file):
     assert lh5_obj.values.attrs["codec"] == "radware_sigcompress"
     assert "codec_shift" in lh5_obj.values.attrs
 
+    lh5_obj, n_rows = store.read_object("/data/struct/wftable_enc/values", lh5_file)
+    assert isinstance(lh5_obj, lgdo.ArrayOfEqualSizedArrays)
+    assert n_rows == 3
+
     lh5_obj, n_rows = store.read_object("/data/struct/wftable_enc", lh5_file)
     assert isinstance(lh5_obj, lgdo.WaveformTable)
     assert isinstance(lh5_obj.values, lgdo.ArrayOfEqualSizedArrays)
     assert n_rows == 3
 
-    lh5_obj, n_rows = store.read_object("/data/struct/wftable_enc/values", lh5_file)
-    assert isinstance(lh5_obj, lgdo.ArrayOfEqualSizedArrays)
-    assert n_rows == 3
-
-    lh5_obj, n_rows = store.read_object(
+    lh5_obj_chain, n_rows = store.read_object(
         "/data/struct/wftable_enc", [lh5_file, lh5_file], decompress=False
     )
     assert n_rows == 6
+    assert isinstance(lh5_obj_chain.values, lgdo.ArrayOfEncodedEqualSizedArrays)
 
-    lh5_obj, n_rows = store.read_object(
+    lh5_obj_chain, n_rows = store.read_object(
         "/data/struct/wftable_enc", [lh5_file, lh5_file], decompress=True
     )
+    assert isinstance(lh5_obj_chain.values, lgdo.ArrayOfEqualSizedArrays)
+    assert np.array_equal(lh5_obj_chain.values[:3], lh5_obj.values)
+    assert np.array_equal(lh5_obj_chain.values[3:], lh5_obj.values)
     assert n_rows == 6
 
 


### PR DESCRIPTION
To do: cross-check object buffer (with start) functionality