### PR TITLE
Fix wrong `Table.eval()` docstring

### DIFF
--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -248,8 +248,8 @@ class Table(Struct):
                     "O1": {
                         "expression": "p1 + p2 * a**2",
                         "parameters": {
-                            "p1": "2",
-                            "p2": "3"
+                            "p1": 2,
+                            "p2": 3
                         }
                     },
                     "O2": {


### PR DESCRIPTION
I believe these are supposed to be numbers not strings.