### PR TITLE
improve performance of read_object with idx by reading in whole objec…

### DIFF
--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -741,7 +741,7 @@ class LH5Store:
                     tmp_shape = (0,) + h5f[name].shape[1:]
                     nda = np.empty(tmp_shape, h5f[name].dtype)
                 else:
-                    nda = h5f[name][source_sel]
+                    nda = h5f[name][...][source_sel]
 
             # special handling for bools
             # (c and Julia store as uint8 so cast to bool)


### PR DESCRIPTION
…t, then slicing

Significantly improves performance of `read_object` when using the `idx` parameter (see #29) at the cost of slightly increased memory use (up to about 150 MB for one channel of a `raw` `cal` file of 15 GB, but typically/always a single channel is loaded at a time). Depending on specifics of file, such as number of events, number of idx, and length of gaps between idx, this can improve performance by up to ~100x.