### PR TITLE
Enable more fine grained control over `h5py.create_dataset()` options and set default HDF5 compression to shuffle + GZip

### DIFF
--- a/docs/source/notebooks/Compression.ipynb
+++ b/docs/source/notebooks/Compression.ipynb
@@ -1,0 +1,417 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4fb3add2",
+   "metadata": {},
+   "source": [
+    "# Data compression\n",
+    "\n",
+    "*legend-pydataobj* gives the user a lot of flexibility in choosing how to compress LGDOs, on disk or in memory, through traditional HDF5 filters or custom waveform compression algorithms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4717f6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lgdo\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd37f6fb",
+   "metadata": {},
+   "source": [
+    "Let's start by creating a dummy LGDO Table:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "498aa4fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = lgdo.Table(\n",
+    "    size=1000,\n",
+    "    col_dict={\n",
+    "        \"col1\": lgdo.Array(np.arange(0, 100, 0.1)),\n",
+    "        \"col2\": lgdo.Array(np.random.rand(1000)),\n",
+    "    },\n",
+    ")\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "607b73c0",
+   "metadata": {},
+   "source": [
+    "and writing it to disk with default settings:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8daee87b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store = lgdo.LH5Store()\n",
+    "store.write_object(data, \"data\", \"data.lh5\", wo_mode=\"of\")\n",
+    "lgdo.show(\"data.lh5\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72693d80",
+   "metadata": {},
+   "source": [
+    "Let's inspect the data on disk:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c23d294a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import h5py\n",
+    "\n",
+    "\n",
+    "def show_h5ds_opts(obj):\n",
+    "    with h5py.File(\"data.lh5\") as f:\n",
+    "        print(obj)\n",
+    "        for attr in [\"compression\", \"compression_opts\", \"shuffle\"]:\n",
+    "            print(\">\", attr, \":\", f[obj].__getattribute__(attr))\n",
+    "        print(\"> size :\", f[obj].id.get_storage_size(), \"B\")\n",
+    "\n",
+    "\n",
+    "show_h5ds_opts(\"data/col1\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98659695",
+   "metadata": {},
+   "source": [
+    "Looks like the data is compressed with [Gzip](http://www.gzip.org) (compression level 4) by default! This default setting is stored in the global `DEFAULT_HDF5_SETTINGS` variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6b50a0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lgdo.lh5_store.DEFAULT_HDF5_SETTINGS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f104ba95",
+   "metadata": {},
+   "source": [
+    "Which specifies the default keyword arguments forwarded to [h5py.Group.create_dataset()](https://docs.h5py.org/en/stable/high/group.html#h5py.Group.create_dataset) and can be overridden by the user\n",
+    "\n",
+    "Examples:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e707f98a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# use another built-in filter\n",
+    "lgdo.lh5_store.DEFAULT_HDF5_SETTINGS = {\"compression\": \"lzf\"}\n",
+    "\n",
+    "# specify filter name and options\n",
+    "lgdo.lh5_store.DEFAULT_HDF5_SETTINGS = {\"compression\": \"gzip\", \"compression_opts\": 7}\n",
+    "\n",
+    "# specify a registered filter provided by hdf5plugin\n",
+    "import hdf5plugin\n",
+    "\n",
+    "lgdo.lh5_store.DEFAULT_HDF5_SETTINGS = {\"compression\": hdf5plugin.Blosc()}\n",
+    "\n",
+    "# shuffle bytes before compressing (typically better compression ratio with no performance penalty)\n",
+    "lgdo.lh5_store.DEFAULT_HDF5_SETTINGS = {\"shuffle\": True, \"compression\": \"gzip\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97a759d5",
+   "metadata": {},
+   "source": [
+    "Useful resources and lists of HDF5 filters:\n",
+    "- [Registered HDF5 filters](https://confluence.hdfgroup.org/display/support/HDF5+Filter+Plugins)\n",
+    "- [Built-in HDF5 filters from h5py](https://docs.h5py.org/en/stable/high/dataset.html#filter-pipeline)\n",
+    "- [Extra filters from hdf5plugin](https://hdf5plugin.readthedocs.io/en/stable/usage.html)\n",
+    "\n",
+    "Let's now re-write the data with the updated default settings:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57dc7086",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store.write_object(data, \"data\", \"data.lh5\", wo_mode=\"of\")\n",
+    "show_h5ds_opts(\"data/col1\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f597a9e2",
+   "metadata": {},
+   "source": [
+    "Nice. Shuffling bytes before compressing significantly reduced size on disk. Last but not least, `create_dataset()` keyword arguments can be passed to `write_object()`. They will be forwarded as is, overriding default settings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d46dd0c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store.write_object(\n",
+    "    data, \"data\", \"data.lh5\", wo_mode=\"of\", shuffle=True, compression=\"gzip\"\n",
+    ")\n",
+    "show_h5ds_opts(\"data/col1\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3253c8cb",
+   "metadata": {},
+   "source": [
+    "Object-specific compression settings are supported via the `compression` LGDO attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c825228f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data[\"col2\"].attrs[\"compression\"] = \"gzip\"\n",
+    "store.write_object(data, \"data\", \"data.lh5\", wo_mode=\"of\")\n",
+    "\n",
+    "show_h5ds_opts(\"data/col1\")\n",
+    "show_h5ds_opts(\"data/col2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a259874",
+   "metadata": {},
+   "source": [
+    "We are now storing table columns with different compression settings."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed517fcd",
+   "metadata": {},
+   "source": [
+    "## Waveform compression\n",
+    "\n",
+    "*legend-pydataobj* implements fast custom waveform compression routines in the [lgdo.compression](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.compression.html) subpackage.\n",
+    "\n",
+    "Let's try them out on some waveform test data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed6add66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from legendtestdata import LegendTestData\n",
+    "\n",
+    "ldata = LegendTestData()\n",
+    "wfs, n_rows = store.read_object(\n",
+    "    \"geds/raw/waveform\",\n",
+    "    ldata.get_path(\"lh5/LDQTA_r117_20200110T105115Z_cal_geds_raw.lh5\"),\n",
+    ")\n",
+    "wfs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91980c0e",
+   "metadata": {},
+   "source": [
+    "Let's encode the waveform values with the [RadwareSigcompress](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.compression.html#lgdo.compression.radware.RadwareSigcompress) codec.\n",
+    "\n",
+    "*Note:* samples from these test waveforms must be shifted by -32768 for compatibility reasons, see [lgdo.compression.radware.encode()](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.compression.html#lgdo.compression.radware.encode)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8e0fc17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lgdo.compression import encode, RadwareSigcompress\n",
+    "\n",
+    "enc_values = encode(wfs.values, RadwareSigcompress(codec_shift=-32768))\n",
+    "enc_values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6482687",
+   "metadata": {},
+   "source": [
+    "The output LGDO is an [ArrayOfEncodedEqualSizedArrays](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.types.html#lgdo.types.encoded.ArrayOfEncodedEqualSizedArrays), which is basically an array of bytes representing the compressed data. How big is this compressed object in bytes?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76c28d99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "enc_values.encoded_data.flattened_data.nda.nbytes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73b2b070",
+   "metadata": {},
+   "source": [
+    "How big was the original data structure?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "298b59bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wfs.values.nda.nbytes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7077856c",
+   "metadata": {},
+   "source": [
+    "It shrank quite a bit!\n",
+    "\n",
+    "Let's now make a `WaveformTable` object wrapping these encoded values, instead of the uncompressed ones, and dump it to disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56db1c14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "enc_wfs = lgdo.WaveformTable(\n",
+    "    values=enc_values,\n",
+    "    t0=wfs.t0,\n",
+    "    dt=wfs.dt,\n",
+    ")\n",
+    "store.write_object(enc_wfs, \"waveforms\", \"data.lh5\", wo_mode=\"o\")\n",
+    "lgdo.show(\"data.lh5\", attrs=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae5abac7",
+   "metadata": {},
+   "source": [
+    "The LH5 structure is more complex now. Note how the compression settings are stored as HDF5 attributes.\n",
+    "\n",
+    "<div class=\"alert alert-warning\">\n",
+    "**Warning:** HDF5 compression is never applied to waveforms compressed with these custom filters.\n",
+    "</div>\n",
+    "\n",
+    "Let's try to read the data back in memory:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc66eb14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obj, _ = store.read_object(\"waveforms\", \"data.lh5\")\n",
+    "obj.values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0cbc18c",
+   "metadata": {},
+   "source": [
+    "Wait, this is not the compressed data we just wrote to disk, it got decompressed on the fly! It's still possible to just return the compressed data though:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3489ed55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obj, _ = store.read_object(\"waveforms\", \"data.lh5\", decompress=False)\n",
+    "obj.values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46b04e4c",
+   "metadata": {},
+   "source": [
+    "And then decompress it manually:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "683b88b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lgdo.compression import decode\n",
+    "\n",
+    "decode(obj.values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3999f30d",
+   "metadata": {},
+   "source": [
+    "Further reading:\n",
+    "\n",
+    "- [Available waveform compression algorithms](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.compression.html)\n",
+    "- [read_object() docstring](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.html#lgdo.lh5_store.LH5Store.read_object)\n",
+    "- [write_object() docstring](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.html#lgdo.lh5_store.LH5Store.write_object)"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/notebooks/DataCompression.ipynb
+++ b/docs/source/notebooks/DataCompression.ipynb
@@ -87,7 +87,7 @@
     "def show_h5ds_opts(obj):\n",
     "    with h5py.File(\"data.lh5\") as f:\n",
     "        print(obj)\n",
-    "        for attr in [\"compression\", \"compression_opts\", \"shuffle\"]:\n",
+    "        for attr in [\"compression\", \"compression_opts\", \"shuffle\", \"chunks\"]:\n",
     "            print(\">\", attr, \":\", f[obj].__getattribute__(attr))\n",
     "        print(\"> size :\", f[obj].id.get_storage_size(), \"B\")\n",
     "\n",
@@ -217,7 +217,21 @@
    "id": "0a259874",
    "metadata": {},
    "source": [
-    "We are now storing table columns with different compression settings."
+    "We are now storing table columns with different compression settings.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "**Note:** since any [h5py.Group.create_dataset()](https://docs.h5py.org/en/stable/high/group.html#h5py.Group.create_dataset) keyword argument can be used in `write_object()` or set in the `hdf5_settings` attribute, other HDF5 dataset settings can be configured, like the chunk size.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d05d4d4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store.write_object(data, \"data\", \"data.lh5\", wo_mode=\"of\", chunks=2)"
    ]
   },
   {
@@ -256,7 +270,9 @@
    "source": [
     "Let's encode the waveform values with the [RadwareSigcompress](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.compression.html#lgdo.compression.radware.RadwareSigcompress) codec.\n",
     "\n",
-    "*Note:* samples from these test waveforms must be shifted by -32768 for compatibility reasons, see [lgdo.compression.radware.encode()](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.compression.html#lgdo.compression.radware.encode)."
+    "<div class=\"alert alert-info\">\n",
+    "**Note:** samples from these test waveforms must be shifted by -32768 for compatibility reasons, see [lgdo.compression.radware.encode()](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.compression.html#lgdo.compression.radware.encode).\n",
+    "</div>"
    ]
   },
   {

--- a/docs/source/notebooks/DataCompression.ipynb
+++ b/docs/source/notebooks/DataCompression.ipynb
@@ -142,7 +142,7 @@
     "lgdo.lh5_store.DEFAULT_HDF5_SETTINGS = {\"compression\": hdf5plugin.Blosc()}\n",
     "\n",
     "# shuffle bytes before compressing (typically better compression ratio with no performance penalty)\n",
-    "lgdo.lh5_store.DEFAULT_HDF5_SETTINGS = {\"shuffle\": True, \"compression\": \"gzip\"}"
+    "lgdo.lh5_store.DEFAULT_HDF5_SETTINGS = {\"shuffle\": True, \"compression\": \"lzf\"}"
    ]
   },
   {
@@ -195,7 +195,7 @@
    "id": "3253c8cb",
    "metadata": {},
    "source": [
-    "Object-specific compression settings are supported via the `compression` LGDO attribute:"
+    "Object-specific compression settings are supported via the `hdf5_settings` LGDO attribute:"
    ]
   },
   {
@@ -205,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data[\"col2\"].attrs[\"compression\"] = \"gzip\"\n",
+    "data[\"col2\"].attrs[\"hdf5_settings\"] = {\"compression\": \"gzip\"}\n",
     "store.write_object(data, \"data\", \"data.lh5\", wo_mode=\"of\")\n",
     "\n",
     "show_h5ds_opts(\"data/col1\")\n",

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -9,4 +9,4 @@ Tutorials are currently available as `Jupyter notebooks on GitHub
    :caption: Contents:
 
    notebooks/LH5Files
-   notebooks/Compression
+   notebooks/DataCompression

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -9,3 +9,4 @@ Tutorials are currently available as `Jupyter notebooks on GitHub
    :caption: Contents:
 
    notebooks/LH5Files
+   notebooks/Compression

--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -1094,6 +1094,8 @@ class LH5Store:
                 # axis) data set, i.e. rows can be appended later
                 # NOTE: this automatically turns chunking on!
                 maxshape = (None,) + nda.shape[1:]
+                h5py_kwargs.setdefault("maxshape", maxshape)
+
                 if wo_mode == "o" and name in group:
                     log.debug(f"overwriting {name} in {group}")
                     del group[name]
@@ -1115,9 +1117,7 @@ class LH5Store:
                     h5py_kwargs |= obj.attrs["hdf5_settings"]
 
                 # create HDF5 dataset
-                ds = group.create_dataset(
-                    name, data=nda, maxshape=maxshape, **h5py_kwargs
-                )
+                ds = group.create_dataset(name, data=nda, **h5py_kwargs)
 
                 # attach HDF5 dataset attributes, but not "compression"!
                 _attrs = obj.getattrs(datatype=True)

--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -38,8 +38,7 @@ LGDO = Union[Array, Scalar, Struct, VectorOfVectors]
 
 log = logging.getLogger(__name__)
 
-DEFAULT_HDF5_SETTINGS: dict[str, ...] = {"compression": None}
-#: The default HDF5 compression settings.
+DEFAULT_HDF5_SETTINGS: dict[str, ...] = {"shuffle": True, "compression": "gzip"}
 
 
 class LH5Store:

--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -980,6 +980,9 @@ class LH5Store:
                 name, group, grp_attrs=obj.attrs, overwrite=(wo_mode == "o")
             )
 
+            # ask not to further compress flattened_data, it is already compressed!
+            obj.encoded_data.flattened_data.attrs["compression"] = None
+
             self.write_object(
                 obj.encoded_data,
                 "encoded_data",

--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -38,7 +38,8 @@ LGDO = Union[Array, Scalar, Struct, VectorOfVectors]
 
 log = logging.getLogger(__name__)
 
-DEFAULT_HDF5_COMPRESSION = "gzip"
+DEFAULT_HDF5_SETTINGS: dict[str, ...] = {"compression": None}
+#: The default HDF5 compression settings.
 
 
 class LH5Store:
@@ -1092,11 +1093,8 @@ class LH5Store:
                     del group[name]
 
                 # set default compression options
-                if isinstance(DEFAULT_HDF5_COMPRESSION, dict):
-                    for k, v in DEFAULT_HDF5_COMPRESSION.items():
-                        h5py_kwargs.setdefault(k, v)
-                else:
-                    h5py_kwargs.setdefault("compression", DEFAULT_HDF5_COMPRESSION)
+                for k, v in DEFAULT_HDF5_SETTINGS.items():
+                    h5py_kwargs.setdefault(k, v)
 
                 # compress using the 'compression' LGDO attribute, if available
                 if "compression" in obj.attrs:

--- a/tests/test_lh5_store.py
+++ b/tests/test_lh5_store.py
@@ -10,7 +10,7 @@ import lgdo
 import lgdo.lh5_store as lh5
 from lgdo import compression
 from lgdo.compression import RadwareSigcompress
-from lgdo.lh5_store import DEFAULT_HDF5_COMPRESSION, LH5Store
+from lgdo.lh5_store import DEFAULT_HDF5_SETTINGS, LH5Store
 
 
 @pytest.fixture(scope="module")
@@ -229,7 +229,10 @@ def test_read_array(lh5_file):
     assert (lh5_obj.nda == np.array([2, 3, 4])).all()
     assert n_rows == 3
     with h5py.File(lh5_file) as h5f:
-        assert h5f["/data/struct/array"].compression is DEFAULT_HDF5_COMPRESSION
+        assert (
+            h5f["/data/struct/array"].compression
+            is DEFAULT_HDF5_SETTINGS["compression"]
+        )
 
 
 def test_read_array_fancy_idx(lh5_file):
@@ -258,11 +261,11 @@ def test_read_vov(lh5_file):
     with h5py.File(lh5_file) as h5f:
         assert (
             h5f["/data/struct/vov/cumulative_length"].compression
-            is DEFAULT_HDF5_COMPRESSION
+            is DEFAULT_HDF5_SETTINGS["compression"]
         )
         assert (
             h5f["/data/struct/vov/flattened_data"].compression
-            is DEFAULT_HDF5_COMPRESSION
+            is DEFAULT_HDF5_SETTINGS["compression"]
         )
 
 
@@ -301,11 +304,11 @@ def test_read_voev(lh5_file):
         assert h5f["/data/struct/voev/encoded_data/flattened_data"].compression is None
         assert (
             h5f["/data/struct/voev/encoded_data/cumulative_length"].compression
-            is DEFAULT_HDF5_COMPRESSION
+            is DEFAULT_HDF5_SETTINGS["compression"]
         )
         assert (
             h5f["/data/struct/voev/decoded_size"].compression
-            is DEFAULT_HDF5_COMPRESSION
+            is DEFAULT_HDF5_SETTINGS["compression"]
         )
 
 
@@ -349,7 +352,10 @@ def test_read_hdf5_compressed_data(lh5_file):
 
     assert "compression" not in lh5_obj["b"].attrs
     with h5py.File(lh5_file) as h5f:
-        assert h5f["/data/struct/table/a"].compression is DEFAULT_HDF5_COMPRESSION
+        assert (
+            h5f["/data/struct/table/a"].compression
+            is DEFAULT_HDF5_SETTINGS["compression"]
+        )
         assert h5f["/data/struct/table/b"].compression == "gzip"
         assert h5f["/data/struct/table/c"].compression == "gzip"
         assert h5f["/data/struct/table/c"].compression_opts == 9
@@ -368,10 +374,17 @@ def test_read_wftable(lh5_file):
 
     with h5py.File(lh5_file) as h5f:
         assert (
-            h5f["/data/struct/wftable/values"].compression is DEFAULT_HDF5_COMPRESSION
+            h5f["/data/struct/wftable/values"].compression
+            is DEFAULT_HDF5_SETTINGS["compression"]
         )
-        assert h5f["/data/struct/wftable/t0"].compression is DEFAULT_HDF5_COMPRESSION
-        assert h5f["/data/struct/wftable/dt"].compression is DEFAULT_HDF5_COMPRESSION
+        assert (
+            h5f["/data/struct/wftable/t0"].compression
+            is DEFAULT_HDF5_SETTINGS["compression"]
+        )
+        assert (
+            h5f["/data/struct/wftable/dt"].compression
+            is DEFAULT_HDF5_SETTINGS["compression"]
+        )
 
 
 def test_read_wftable_encoded(lh5_file):
@@ -417,10 +430,12 @@ def test_read_wftable_encoded(lh5_file):
         )
         assert h5f["/data/struct/wftable_enc/values/decoded_size"].compression is None
         assert (
-            h5f["/data/struct/wftable_enc/t0"].compression is DEFAULT_HDF5_COMPRESSION
+            h5f["/data/struct/wftable_enc/t0"].compression
+            is DEFAULT_HDF5_SETTINGS["compression"]
         )
         assert (
-            h5f["/data/struct/wftable_enc/dt"].compression is DEFAULT_HDF5_COMPRESSION
+            h5f["/data/struct/wftable_enc/dt"].compression
+            is DEFAULT_HDF5_SETTINGS["compression"]
         )
 
 

--- a/tests/test_lh5_store.py
+++ b/tests/test_lh5_store.py
@@ -297,6 +297,17 @@ def test_read_voev(lh5_file):
     assert isinstance(lh5_obj, lgdo.VectorOfEncodedVectors)
     assert n_rows == 6
 
+    with h5py.File(lh5_file) as h5f:
+        assert h5f["/data/struct/voev/encoded_data/flattened_data"].compression is None
+        assert (
+            h5f["/data/struct/voev/encoded_data/cumulative_length"].compression
+            is DEFAULT_HDF5_COMPRESSION
+        )
+        assert (
+            h5f["/data/struct/voev/decoded_size"].compression
+            is DEFAULT_HDF5_COMPRESSION
+        )
+
 
 def test_read_voev_fancy_idx(lh5_file):
     store = LH5Store()
@@ -396,6 +407,21 @@ def test_read_wftable_encoded(lh5_file):
     assert np.array_equal(lh5_obj_chain.values[:3], lh5_obj.values)
     assert np.array_equal(lh5_obj_chain.values[3:], lh5_obj.values)
     assert n_rows == 6
+
+    with h5py.File(lh5_file) as h5f:
+        assert (
+            h5f[
+                "/data/struct/wftable_enc/values/encoded_data/flattened_data"
+            ].compression
+            is None
+        )
+        assert h5f["/data/struct/wftable_enc/values/decoded_size"].compression is None
+        assert (
+            h5f["/data/struct/wftable_enc/t0"].compression is DEFAULT_HDF5_COMPRESSION
+        )
+        assert (
+            h5f["/data/struct/wftable_enc/dt"].compression is DEFAULT_HDF5_COMPRESSION
+        )
 
 
 def test_read_with_field_mask(lh5_file):

--- a/tests/test_lh5_store.py
+++ b/tests/test_lh5_store.py
@@ -603,6 +603,7 @@ def test_write_with_hdf5_compression(lgnd_file, tmptestdir):
         f"{tmptestdir}/tmp-pygama-hdf5-compressed-wfs.lh5",
         wo_mode="overwrite_file",
         compression=None,
+        shuffle=False,
     )
     with h5py.File(f"{tmptestdir}/tmp-pygama-hdf5-compressed-wfs.lh5") as h5f:
         assert h5f["/geds/raw/waveform/values"].compression is None

--- a/tests/test_lh5_store.py
+++ b/tests/test_lh5_store.py
@@ -10,7 +10,7 @@ import lgdo
 import lgdo.lh5_store as lh5
 from lgdo import compression
 from lgdo.compression import RadwareSigcompress
-from lgdo.lh5_store import LH5Store
+from lgdo.lh5_store import DEFAULT_HDF5_COMPRESSION, LH5Store
 
 
 @pytest.fixture(scope="module")
@@ -132,6 +132,14 @@ def lh5_file(tmptestdir):
     col_dict = {
         "a": lgdo.Array(nda=np.array([1, 2, 3, 4]), attrs={"attr": 9}),
         "b": lgdo.Array(nda=np.array([5, 6, 7, 8]), attrs={"compression": "gzip"}),
+        "c": lgdo.Array(
+            nda=np.array([5, 6, 7, 8]),
+            attrs={"compression": {"compression": "gzip", "compression_opts": 9}},
+        ),
+        "d": lgdo.Array(
+            nda=np.array([5, 6, 7, 8]),
+            attrs={"compression": None},
+        ),
     }
 
     struct.add_field("table", lgdo.Table(col_dict=col_dict, attrs={"stuff": 5}))
@@ -176,6 +184,8 @@ def lh5_file(tmptestdir):
         wo_mode="append",
     )
 
+    assert struct["table"]["b"].attrs["compression"] == "gzip"
+
     return f"{tmptestdir}/tmp-pygama-lgdo-types.lh5"
 
 
@@ -208,6 +218,8 @@ def test_read_scalar(lh5_file):
     assert lh5_obj.value == 10
     assert n_rows == 1
     assert lh5_obj.attrs["sth"] == 1
+    with h5py.File(lh5_file) as h5f:
+        assert h5f["/data/struct/scalar"].compression is None
 
 
 def test_read_array(lh5_file):
@@ -216,6 +228,8 @@ def test_read_array(lh5_file):
     assert isinstance(lh5_obj, lgdo.Array)
     assert (lh5_obj.nda == np.array([2, 3, 4])).all()
     assert n_rows == 3
+    with h5py.File(lh5_file) as h5f:
+        assert h5f["/data/struct/array"].compression is DEFAULT_HDF5_COMPRESSION
 
 
 def test_read_array_fancy_idx(lh5_file):
@@ -240,6 +254,16 @@ def test_read_vov(lh5_file):
 
     assert n_rows == 3
     assert lh5_obj.attrs["myattr"] == 2
+
+    with h5py.File(lh5_file) as h5f:
+        assert (
+            h5f["/data/struct/vov/cumulative_length"].compression
+            is DEFAULT_HDF5_COMPRESSION
+        )
+        assert (
+            h5f["/data/struct/vov/flattened_data"].compression
+            is DEFAULT_HDF5_COMPRESSION
+        )
 
 
 def test_read_vov_fancy_idx(lh5_file):
@@ -314,8 +338,11 @@ def test_read_hdf5_compressed_data(lh5_file):
 
     assert "compression" not in lh5_obj["b"].attrs
     with h5py.File(lh5_file) as h5f:
+        assert h5f["/data/struct/table/a"].compression is DEFAULT_HDF5_COMPRESSION
         assert h5f["/data/struct/table/b"].compression == "gzip"
-        assert h5f["/data/struct/table/a"].compression is None
+        assert h5f["/data/struct/table/c"].compression == "gzip"
+        assert h5f["/data/struct/table/c"].compression_opts == 9
+        assert h5f["/data/struct/table/d"].compression is None
 
 
 def test_read_wftable(lh5_file):
@@ -327,6 +354,13 @@ def test_read_wftable(lh5_file):
     lh5_obj, n_rows = store.read_object("/data/struct/wftable", [lh5_file, lh5_file])
     assert n_rows == 6
     assert lh5_obj.values.attrs["custom"] == 8
+
+    with h5py.File(lh5_file) as h5f:
+        assert (
+            h5f["/data/struct/wftable/values"].compression is DEFAULT_HDF5_COMPRESSION
+        )
+        assert h5f["/data/struct/wftable/t0"].compression is DEFAULT_HDF5_COMPRESSION
+        assert h5f["/data/struct/wftable/dt"].compression is DEFAULT_HDF5_COMPRESSION
 
 
 def test_read_wftable_encoded(lh5_file):
@@ -503,6 +537,35 @@ def test_read_compressed_lgnd_waveform_table(lgnd_file, enc_lgnd_file):
     wft, _ = store.read_object("/geds/raw/waveform", enc_lgnd_file)
     assert isinstance(wft.values, lgdo.ArrayOfEqualSizedArrays)
     assert "compression" not in wft.values.attrs
+
+
+def test_write_with_hdf5_compression(lgnd_file, tmptestdir):
+    store = LH5Store()
+    wft, n_rows = store.read_object("/geds/raw/waveform", lgnd_file)
+    store.write_object(
+        wft,
+        "/geds/raw/waveform",
+        f"{tmptestdir}/tmp-pygama-hdf5-compressed-wfs.lh5",
+        wo_mode="overwrite_file",
+        compression="gzip",
+        compression_opts=9,
+        shuffle=True,
+    )
+    with h5py.File(f"{tmptestdir}/tmp-pygama-hdf5-compressed-wfs.lh5") as h5f:
+        assert h5f["/geds/raw/waveform/values"].compression == "gzip"
+        assert h5f["/geds/raw/waveform/values"].compression_opts == 9
+        assert h5f["/geds/raw/waveform/values"].shuffle is True
+
+    store.write_object(
+        wft,
+        "/geds/raw/waveform",
+        f"{tmptestdir}/tmp-pygama-hdf5-compressed-wfs.lh5",
+        wo_mode="overwrite_file",
+        compression=None,
+    )
+    with h5py.File(f"{tmptestdir}/tmp-pygama-hdf5-compressed-wfs.lh5") as h5f:
+        assert h5f["/geds/raw/waveform/values"].compression is None
+        assert h5f["/geds/raw/waveform/values"].shuffle is False
 
 
 # First test that we can overwrite a table with the same name without deleting the original field


### PR DESCRIPTION
See new tutorial for summary of the features.

The default compression settings are not final, we can discuss.