### PR TITLE
improve read_object speed when passing idx

### DIFF
--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -764,7 +764,8 @@ class LH5Store:
                     obj_buf.resize(buf_size)
                 dest_sel = np.s_[obj_buf_start:buf_size]
                 
-                # until better solution found
+                # this is required to make the read of multiple files faster
+                # until better solution found.
                 if (use_h5idx):
                     h5f[name].read_direct(obj_buf.nda, source_sel, dest_sel)
                 else:
@@ -779,6 +780,10 @@ class LH5Store:
                     if (use_h5idx):
                         nda = h5f[name][source_sel]
                     else:
+                        # a copy is made in case this is given to an obj_buf that
+                        # then needs to be resized. A view is returned by the
+                        # source_sel indexing, which cannot be resized by ndarray.resize().
+                        # This occurs in particular when multiple files are being read.
                         nda = np.copy(h5f[name][...][source_sel])
 
             # special handling for bools

--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -239,9 +239,7 @@ class LH5Store:
         obj_buf
             Read directly into memory provided in `obj_buf`. Note: the buffer
             will be expanded to accommodate the data requested. To maintain the
-            buffer length, send in ``n_rows = len(obj_buf)``. Note that passing
-            this parameter will ignore the ``use_h5idx`` flag and suffer a speed
-            penalty if also passing ``idx``.
+            buffer length, send in ``n_rows = len(obj_buf)``.
         obj_buf_start
             Start location in ``obj_buf`` for read. For concatenating data to
             array-like objects.

--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -183,7 +183,7 @@ class LH5Store:
         the whole object and then indexing the desired rows. The default behavior (``use_h5idx=False``)
         is to use slightly more memory for a much faster read. Note that there is approximately a x2
         penalty to speed if ``idx`` contains all of the rows of the object, as opposed to just reading
-        the whole object in without the ``idx`` parameter. See 
+        the whole object in without the ``idx`` parameter. See
         `legend-pydataobj #29 <https://github.com/legend-exp/legend-pydataobj/issues/29>`_
         for additional information.
 

--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -177,14 +177,14 @@ class LH5Store:
     ) -> tuple[LGDO, int]:
         """Read LH5 object data from a file.
 
-        Use the``idx`` parameter to read out particular rows of the data. The ``use_h5idx`` flag
+        Use the ``idx`` parameter to read out particular rows of the data. The ``use_h5idx`` flag
         controls whether *only* those rows are read from disk or if the rows are indexed after reading
         the entire object. Reading individual rows can be orders of magnitude slower than reading
         the whole object and then indexing the desired rows. The default behavior (``use_h5idx=False``)
         is to use slightly more memory for a much faster read. Note that there is approximately a x2
         penalty to speed if ``idx`` contains all of the rows of the object, as opposed to just reading
-        the whole object in without the ``idx`` parameter. See
-        [legend-pydataobj #29](https://github.com/legend-exp/legend-pydataobj/issues/29)
+        the whole object in without the ``idx`` parameter. See 
+        `legend-pydataobj #29 <https://github.com/legend-exp/legend-pydataobj/issues/29>`_
         for additional information.
 
         Parameters

--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -284,6 +284,7 @@ class LH5Store:
                     start_row=start_row,
                     n_rows=n_rows_i,
                     idx=idx_i,
+                    use_h5idx=use_h5idx,
                     field_mask=field_mask,
                     obj_buf=obj_buf,
                     obj_buf_start=obj_buf_start,
@@ -381,6 +382,7 @@ class LH5Store:
                     start_row=start_row,
                     n_rows=n_rows,
                     idx=idx,
+                    use_h5idx=use_h5idx,
                     decompress=decompress,
                 )
             # modify datatype in attrs if a field_mask was used
@@ -427,6 +429,7 @@ class LH5Store:
                     start_row=start_row,
                     n_rows=n_rows,
                     idx=idx,
+                    use_h5idx=use_h5idx,
                     obj_buf=fld_buf,
                     obj_buf_start=obj_buf_start,
                     decompress=decompress,
@@ -596,6 +599,7 @@ class LH5Store:
                 start_row=start_row,
                 n_rows=n_rows,
                 idx=idx,
+                use_h5idx=use_h5idx,
                 obj_buf=cumulen_buf,
                 obj_buf_start=obj_buf_start,
             )
@@ -620,6 +624,7 @@ class LH5Store:
                     start_row=start_row,
                     n_rows=n_rows,
                     idx=idx2,
+                    use_h5idx=use_h5idx,
                 )
                 fd_starts = fd_starts.nda  # we just need the nda
                 if fd_start is None:
@@ -702,6 +707,7 @@ class LH5Store:
                 start_row=fd_start,
                 n_rows=fd_n_rows,
                 idx=fd_idx,
+                use_h5idx=use_h5idx,
                 obj_buf=fd_buf,
                 obj_buf_start=fd_buf_start,
             )
@@ -757,7 +763,13 @@ class LH5Store:
                 if len(obj_buf) < buf_size:
                     obj_buf.resize(buf_size)
                 dest_sel = np.s_[obj_buf_start:buf_size]
-                h5f[name].read_direct(obj_buf.nda, source_sel, dest_sel)
+                
+                # until better solution found
+                if (use_h5idx):
+                    h5f[name].read_direct(obj_buf.nda, source_sel, dest_sel)
+                else:
+                    obj_buf.nda[dest_sel] = np.copy(h5f[name][...][source_sel])
+
                 nda = obj_buf.nda
             else:
                 if n_rows == 0:
@@ -767,7 +779,7 @@ class LH5Store:
                     if (use_h5idx):
                         nda = h5f[name][source_sel]
                     else:
-                        nda = h5f[name][...][source_sel]
+                        nda = np.copy(h5f[name][...][source_sel])
 
             # special handling for bools
             # (c and Julia store as uint8 so cast to bool)

--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -219,8 +219,8 @@ class LH5Store:
             which conserves memory at the cost of speed. There can be a significant penalty
             to speed for larger files (1 - 2 orders of magnitude longer time).
             ``False`` (default) will read the entire object into memory before
-            performing the indexing. The default is much faster but requires additional memory, 
-            though a relatively small amount in the typical use case. It is recommended to 
+            performing the indexing. The default is much faster but requires additional memory,
+            though a relatively small amount in the typical use case. It is recommended to
             leave this parameter as its default.
         field_mask
             For tables and structs, determines which fields get written out.
@@ -775,7 +775,7 @@ class LH5Store:
             if idx is not None:
                 # check if idx is empty and convert to slice instead
                 if len(idx[0]) == 0:
-                    source_sel = np.s_[0 : 0]
+                    source_sel = np.s_[0:0]
                     change_idx_to_slice = True
                 # check if idx is contiguous and increasing
                 # if so, convert it to a slice instead (faster)
@@ -786,7 +786,7 @@ class LH5Store:
                     source_sel = idx
             else:
                 source_sel = np.s_[start_row : start_row + n_rows_to_read]
-                
+
             # Now read the array
             if obj_buf is not None and n_rows_to_read > 0:
                 buf_size = obj_buf_start + n_rows_to_read

--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -173,18 +173,18 @@ class LH5Store:
         field_mask: dict[str, bool] | list[str] | tuple[str] = None,
         obj_buf: LGDO = None,
         obj_buf_start: int = 0,
-        decompress: bool = True,        
+        decompress: bool = True,
     ) -> tuple[LGDO, int]:
         """Read LH5 object data from a file.
 
         Use the``idx`` parameter to read out particular rows of the data. The ``use_h5idx`` flag
-        controls whether *only* those rows are read from disk or if the rows are indexed after reading 
-        the entire object. Reading individual rows can be orders of magnitude slower than reading 
+        controls whether *only* those rows are read from disk or if the rows are indexed after reading
+        the entire object. Reading individual rows can be orders of magnitude slower than reading
         the whole object and then indexing the desired rows. The default behavior (``use_h5idx=False``)
-        is to use slightly more memory for a much faster read. Note that there is approximately a x2 
+        is to use slightly more memory for a much faster read. Note that there is approximately a x2
         penalty to speed if ``idx`` contains all of the rows of the object, as opposed to just reading
-        the whole object in without the ``idx`` parameter. See 
-        [legend-pydataobj #29](https://github.com/legend-exp/legend-pydataobj/issues/29) 
+        the whole object in without the ``idx`` parameter. See
+        [legend-pydataobj #29](https://github.com/legend-exp/legend-pydataobj/issues/29)
         for additional information.
 
         Parameters
@@ -204,27 +204,27 @@ class LH5Store:
             values (see below).
         idx
             For NumPy-style "fancying indexing" for the read to select only some
-            rows, e.g. after applying some cuts to particular columns. 
-            Only selection along the first axis is supported, so tuple arguments 
-            must be one-tuples.  If `n_rows` is not false, `idx` will be truncated to 
-            `n_rows` before reading. To use with a list of files, can pass in a list of 
+            rows, e.g. after applying some cuts to particular columns.
+            Only selection along the first axis is supported, so tuple arguments
+            must be one-tuples.  If `n_rows` is not false, `idx` will be truncated to
+            `n_rows` before reading. To use with a list of files, can pass in a list of
             `idx`'s (one for each file) or use a long contiguous list (e.g. built from a previous
             identical read). If used in conjunction with `start_row` and `n_rows`,
             will be sliced to obey those constraints, where `n_rows` is
             interpreted as the (max) number of *selected* values (in `idx`) to be
             read out. Note that the ``use_h5idx`` parameter controls some behaviour of the
             read and that the default behavior (``use_h5idx=False``) prioritizes speed over
-            a small memory penalty. Note also that there is approximately a x2 
+            a small memory penalty. Note also that there is approximately a x2
             penalty to speed if ``idx`` contains all of the rows of the object, as opposed to just reading
             the whole object in without the ``idx`` parameter.
         use_h5idx
-            ``True`` will directly pass the ``idx`` parameter to the underlying 
+            ``True`` will directly pass the ``idx`` parameter to the underlying
             ``h5py`` call such that only the selected rows are read directly into memory,
             which conserves memory at the cost of speed. There can be a significant penalty
             to speed for larger files (1 - 2 orders of magnitude longer time).
             ``False`` (default) will read the entire object into memory before
             performing the indexing. The default is much faster (1-2 orders of
-            magnitude) but requires additional memory, though a relatively small 
+            magnitude) but requires additional memory, though a relatively small
             amount in the typical use case. It is recommended to leave this parameter as
             its default.
         field_mask
@@ -266,7 +266,7 @@ class LH5Store:
             # to know whether we are reading in a list of files.
             # this is part of the fix for reading data by idx
             # (see https://github.com/legend-exp/legend-pydataobj/issues/29)
-            # so that we only make a copy of the data if absolutely necessary 
+            # so that we only make a copy of the data if absolutely necessary
             # or if we can read the data from file without having to make a copy
             self.in_file_loop = True
 
@@ -289,7 +289,7 @@ class LH5Store:
                 else:
                     idx_i = None
                 n_rows_i = n_rows - n_rows_read
-                
+
                 # maybe someone passed in a list of len==1?
                 if i == (len(lh5_file) - 1):
                     self.in_file_loop = False
@@ -785,7 +785,7 @@ class LH5Store:
                 if len(obj_buf) < buf_size:
                     obj_buf.resize(buf_size)
                 dest_sel = np.s_[obj_buf_start:buf_size]
-                
+
                 # this is required to make the read of multiple files faster
                 # until a better solution found.
                 if idx is None or use_h5idx:
@@ -807,12 +807,12 @@ class LH5Store:
                         nda = h5f[name][...][source_sel]
 
                         # if reading a list of files recursively, this is given to obj_buf on
-                        # the first file read. obj_buf needs to be resized and therefore 
-                        # it needs to hold the data itself (not a view of the data). 
-                        # a view is returned by the source_sel indexing, which cannot be resized 
+                        # the first file read. obj_buf needs to be resized and therefore
+                        # it needs to hold the data itself (not a view of the data).
+                        # a view is returned by the source_sel indexing, which cannot be resized
                         # by ndarray.resize().
-                        if hasattr(self, 'in_file_loop') and self.in_file_loop:
-                            nda = np.copy(nda)  
+                        if hasattr(self, "in_file_loop") and self.in_file_loop:
+                            nda = np.copy(nda)
 
             # special handling for bools
             # (c and Julia store as uint8 so cast to bool)

--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -741,7 +741,7 @@ class LH5Store:
                     tmp_shape = (0,) + h5f[name].shape[1:]
                     nda = np.empty(tmp_shape, h5f[name].dtype)
                 else:
-                    nda = h5f[name][source_sel]
+                    nda = h5f[name][...][source_sel]
 
             # special handling for bools
             # (c and Julia store as uint8 so cast to bool)

--- a/src/lgdo/lh5_store.py
+++ b/src/lgdo/lh5_store.py
@@ -181,7 +181,7 @@ class LH5Store:
         controls whether *only* those rows are read from disk or if the rows are indexed after reading 
         the entire object. Reading individual rows can be orders of magnitude slower than reading 
         the whole object and then indexing the desired rows. The default behavior (``use_h5idx=False``)
-        is to use slightly more memory for a much faster read. Note that there is approximately a 2x 
+        is to use slightly more memory for a much faster read. Note that there is approximately a x2 
         penalty to speed if ``idx`` contains all of the rows of the object, as opposed to just reading
         the whole object in without the ``idx`` parameter. See 
         [legend-pydataobj #29](https://github.com/legend-exp/legend-pydataobj/issues/29) 
@@ -214,7 +214,7 @@ class LH5Store:
             interpreted as the (max) number of *selected* values (in `idx`) to be
             read out. Note that the ``use_h5idx`` parameter controls some behaviour of the
             read and that the default behavior (``use_h5idx=False``) prioritizes speed over
-            a small memory penalty. Note also that there is approximately a 2x 
+            a small memory penalty. Note also that there is approximately a x2 
             penalty to speed if ``idx`` contains all of the rows of the object, as opposed to just reading
             the whole object in without the ``idx`` parameter.
         use_h5idx


### PR DESCRIPTION
See #29 for details of issue and fix. "Fixes" this issue by sacrificing a small amount memory for additional speed. This can improve `read_object` speeds when using the `idx` parameter by more than x50 depending on how many events are selected from a file. 

There is now a x2 speed penalty if the user passes in `idx` that corresponds to all events compared to just reading everything without any `idx`. In the future, `read_object` could check if the user did this. For now, however, it is up the user to check.