### PR TITLE
Add vectorized operations to VectorOfVectors

### DIFF
--- a/src/lgdo/types/vectorofvectors.py
+++ b/src/lgdo/types/vectorofvectors.py
@@ -517,7 +517,8 @@ def _nb_build_cl(sorted_array_in: NDArray, cumulative_length_out: NDArray) -> ND
             "f8",
             "c8",
             "c16",
-        ] for size_type in ['i4', 'i8', 'u4', 'u8']
+        ]
+        for size_type in ["i4", "i8", "u4", "u8"]
     ],
     "(l,m),(l),(n)",
     **nb_kwargs,

--- a/tests/types/test_vectorofvectors.py
+++ b/tests/types/test_vectorofvectors.py
@@ -217,6 +217,7 @@ def test_replace(lgdo_vov):
         ]
     )
 
+
 def test_set_vector_unsafe(lgdo_vov):
     desired = [
         np.array([1, 2], dtype=lgdo_vov.dtype),
@@ -229,23 +230,17 @@ def test_set_vector_unsafe(lgdo_vov):
     desired_lens = np.array([len(arr) for arr in desired])
 
     # test sequential filling
-    second_vov = lgdo.VectorOfVectors(
-        shape_guess=(5, 5),
-        dtype=lgdo_vov.dtype
-    )
+    second_vov = lgdo.VectorOfVectors(shape_guess=(5, 5), dtype=lgdo_vov.dtype)
     for i, arr in enumerate(desired):
         second_vov._set_vector_unsafe(i, arr)
-        desired_aoa[i, :len(arr)] = arr
-    assert(lgdo_vov == second_vov)
+        desired_aoa[i, : len(arr)] = arr
+    assert lgdo_vov == second_vov
 
     # test vectorized filling
-    third_vov = lgdo.VectorOfVectors(
-        shape_guess=(5, 5),
-        dtype=lgdo_vov.dtype
-    )
+    third_vov = lgdo.VectorOfVectors(shape_guess=(5, 5), dtype=lgdo_vov.dtype)
     third_vov._set_vector_unsafe(0, desired_aoa, desired_lens)
-    assert(lgdo_vov == third_vov)
-    
+    assert lgdo_vov == third_vov
+
 
 def test_iter(lgdo_vov):
     desired = [


### PR DESCRIPTION
Enabled vectorized use of _set_vector_unsafe. This creates a large speedup compared to setting values in a python loop. This feature is useful for writing VectorOfVector outputs in ProcessingChain

Also made it so that the equals operator of VectorOfVectors will work correctly if the flattened array is padded at the end.

Note that the other "unsafe" modifier functions for VectorOfVectors have not (yet) been touched, but could also benefit from vectorization. I could add these features to this pull request, but I'm not sure it is worth the effort given discussion about changing to a Awkward Array-based backend

See https://github.com/legend-exp/legend-pydataobj/pull/41; this is the same changes disentangled from other recent changes