### PR TITLE
Added depth option to show and lh5ls

### DIFF
--- a/src/lgdo/cli.py
+++ b/src/lgdo/cli.py
@@ -38,7 +38,13 @@ def lh5ls():
     parser.add_argument(
         "--attributes", "-a", action="store_true", help="""Print HDF5 attributes too"""
     )
-    parser.add_argument("--depth", "-d", type=int, default=None, help="""Maximum tree depth of groups to print""")
+    parser.add_argument(
+        "--depth",
+        "-d",
+        type=int,
+        default=None,
+        help="""Maximum tree depth of groups to print""",
+    )
 
     args = parser.parse_args()
 

--- a/src/lgdo/cli.py
+++ b/src/lgdo/cli.py
@@ -5,7 +5,7 @@ import sys
 
 import lgdo
 import lgdo.logging
-from lgdo import show
+from lgdo.lh5 import show
 
 
 def lh5ls():
@@ -26,7 +26,6 @@ def lh5ls():
     )
     parser.add_argument(
         "--debug",
-        "-d",
         action="store_true",
         help="""Increase the program verbosity to maximum""",
     )
@@ -39,6 +38,7 @@ def lh5ls():
     parser.add_argument(
         "--attributes", "-a", action="store_true", help="""Print HDF5 attributes too"""
     )
+    parser.add_argument("--depth", "-d", type=int, default=None, help="""Maximum tree depth of groups to print""")
 
     args = parser.parse_args()
 
@@ -53,4 +53,4 @@ def lh5ls():
         print(lgdo.__version__)  # noqa: T201
         sys.exit()
 
-    show(args.lh5_file, args.lh5_group, attrs=args.attributes)
+    show(args.lh5_file, args.lh5_group, attrs=args.attributes, depth=args.depth)

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -1371,7 +1371,7 @@ def show(
     └── wf_std · array<1>{real}
     """
     # check tree depth if we are using it
-    if depth is not None and depth<=0:
+    if depth is not None and depth <= 0:
         return
 
     # open file
@@ -1429,7 +1429,7 @@ def show(
                 indent=indent + ("    " if killme else "│   "),
                 header=False,
                 attrs=attrs,
-                depth=depth-1 if depth else None
+                depth=depth - 1 if depth else None,
             )
 
         # break or move to next key

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -1337,6 +1337,7 @@ def show(
     attrs: bool = False,
     indent: str = "",
     header: bool = True,
+    depth: int | None = None,
 ) -> None:
     """Print a tree of LH5 file contents with LGDO datatype.
 
@@ -1352,6 +1353,8 @@ def show(
         indent the diagram with this string.
     header
         print `lh5_group` at the top of the diagram.
+    depth
+        maximum tree depth of groups to print
 
     Examples
     --------
@@ -1367,6 +1370,10 @@ def show(
     │   └── values · array_of_equalsized_arrays<1,1>{real}
     └── wf_std · array<1>{real}
     """
+    # check tree depth if we are using it
+    if depth is not None and depth<=0:
+        return
+
     # open file
     if isinstance(lh5_file, str):
         lh5_file = h5py.File(expand_path(lh5_file), "r")
@@ -1422,6 +1429,7 @@ def show(
                 indent=indent + ("    " if killme else "│   "),
                 header=False,
                 attrs=attrs,
+                depth=depth-1 if depth else None
             )
 
         # break or move to next key


### PR DESCRIPTION
Added depth option to restrict maximum tree depth of groups to print when calling show or lh5ls. So instead of
```
lh5ls /global/cfs/cdirs/m2676/data/lngs/l200/public/prodenv/prod-orig/archive/raw-v01.00/generated/tier/raw/cal/p04/r001/l200-p04-r001-cal-20230421T131817Z-tier_raw.lh5
├── FCConfig · table{packet_id,packet_len,readout_id,fcid,telid,nadcs,ntriggers,nsamples,adcbits,sumlength,blprecision,mastercards,triggercards,adccards,gps,ch_board_id,ch_inputnum,board_rev,board_uid}
│   ├── adcbits · array<1>{real}
│   ├── adccards · array<1>{real}
│   ├── blprecision · array<1>{real}
│   ├── board_rev · array<1>{array<1>{real}}
│   │   ├── cumulative_length · array<1>{real}
│   │   └── flattened_data · array<1>{real}
│   ├── board_uid · array<1>{array<1>{real}}
│   │   ├── cumulative_length · array<1>{real}
│   │   └── flattened_data · array<1>{real}
│   ├── ch_board_id · array<1>{array<1>{real}}
...
```
you can do
```
lh5ls -d1 /global/cfs/cdirs/m2676/data/lngs/l200/public/prodenv/prod-orig/archive/raw-v01.00/generated/tier/raw/cal/p04/r001/l200-p04-r001-cal-20230421T131817Z-tier_raw.lh5
├── FCConfig · table{packet_id,packet_len,readout_id,fcid,telid,nadcs,ntriggers,nsamples,adcbits,sumlength,blprecision,mastercards,triggercards,adccards,gps,ch_board_id,ch_inputnum,board_rev,board_uid}
├── ORRunDecoderForRun · table{subrun_number,runstartorstop,quickstartrun,remotecontrolrun,heartbeatrecord,endsubrunrecord,startsubrunrecord,run_number,time}
├── OrcaHeader · string
├── ch1027200 · HDF5 group
├── ch1027201 · HDF5 group
├── ch1078400 · HDF5 group
...
```

Note: I replaced the functionality of `-d` to do `--depth` instead of `--debug` in `lh5ls`. I did this because `-d` is a fairly traditional shorthand to use for this, and because `--debug` should be used rarely enough that it probably can live without a shorthand. This can be changed if it is a problem though.