### PR TITLE
Reimplement `Table.eval()`, now handling `VectorOfVectors`

### DIFF
--- a/src/lgdo/types/arrayofequalsizedarrays.py
+++ b/src/lgdo/types/arrayofequalsizedarrays.py
@@ -70,6 +70,8 @@ class ArrayOfEqualSizedArrays(Array):
             if nda is None:
                 s = shape
             else:
+                if not isinstance(nda, np.ndarray):
+                    nda = np.array(nda)
                 s = nda.shape
             self.dims = (1, len(s) - 1)
         else:

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -276,10 +276,10 @@ class Table(Struct):
         for obj in c.co_names:
             if obj in self.keys():
                 if isinstance(self[obj], VectorOfVectors):
-                    self_unwrap[obj] = self[obj].view_as("ak")
+                    self_unwrap[obj] = self[obj].view_as("ak", with_units=False)
                     has_ak = True
                 else:
-                    self_unwrap[obj] = self[obj].view_as("np")
+                    self_unwrap[obj] = self[obj].view_as("np", with_units=False)
 
         # use numexpr if we are only dealing with numpy data types
         if not has_ak:

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -5,8 +5,7 @@ equal length and corresponding utilities.
 from __future__ import annotations
 
 import logging
-import re
-from typing import Any
+from typing import Any, Mapping
 from warnings import warn
 
 import awkward as ak
@@ -18,6 +17,7 @@ from pandas.io.formats import format as fmt
 from .array import Array
 from .arrayofequalsizedarrays import ArrayOfEqualSizedArrays
 from .lgdo import LGDO
+from .scalar import Scalar
 from .struct import Struct
 from .vectorofvectors import VectorOfVectors
 
@@ -37,8 +37,6 @@ class Table(Struct):
     resize it before passing to data processing functions, as they will call
     :meth:`__len__` to access valid data, which returns the ``size`` attribute.
     """
-
-    # TODO: overload getattr to allow access to fields as object attributes?
 
     def __init__(
         self,
@@ -217,102 +215,114 @@ class Table(Struct):
         )
         return self.view_as(library="pd", cols=cols, prefix=prefix)
 
-    def eval(self, expr_config: dict) -> Table:
-        """Apply column operations to the table and return a new table holding
-        the resulting columns.
+    def eval(
+        self,
+        expr: str,
+        parameters: Mapping[str, str] = None,
+    ) -> LGDO:
+        """Apply column operations to the table and return a new LGDO.
 
-        Currently defers all the job to :meth:`numexpr.evaluate`. This
-        might change in the future.
+        Internally uses :func:`numexpr.evaluate` if dealing with columns
+        representable as NumPy arrays or :func:`eval` if
+        :class:`.VectorOfVectors` are involved. In the latter case, the VoV
+        columns are viewed as :class:`ak.Array` and the respective routines are
+        therefore available.
 
         Parameters
         ----------
-        expr_config
-            dictionary that configures expressions according the following
-            specification:
+        expr
+            if the expression only involves non-:class:`.VectorOfVectors`
+            columns, the syntax is the one supported by
+            :func:`numexpr.evaluate` (see `here
+            <https://numexpr.readthedocs.io/projects/NumExpr3/en/latest/index.html>`_
+            for documentation). Note: because of internal limitations,
+            reduction operations must appear the last in the stack. If at least
+            one considered column is a :class:`.VectorOfVectors`, plain
+            :func:`eval` is used and :class:`ak.Array` transforms can be used
+            through the ``ak.`` prefix. (NumPy functions are analogously
+            accessible through ``np.``). See also examples below.
+        parameters
+            a dictionary of function parameters. Passed to
+            :func:`numexpr.evaluate`` as `local_dict` argument or to
+            :func:`eval` as `locals` argument.
 
-            .. code-block:: js
-
-                {
-                    "O1": {
-                        "expression": "p1 + p2 * a**2",
-                        "parameters": {
-                            "p1": 2,
-                            "p2": 3
-                        }
-                    },
-                    "O2": {
-                        "expression": "O1 - b"
-                    }
-                    // ...
-                }
-
-            where:
-
-            - ``expression`` is an expression string supported by
-              :meth:`numexpr.evaluate` (see also `here
-              <https://numexpr.readthedocs.io/projects/NumExpr3/en/latest/index.html>`_
-              for documentation). Note: because of internal limitations,
-              reduction operations must appear the last in the stack.
-            - ``parameters`` is a dictionary of function parameters. Passed to
-              :meth:`numexpr.evaluate`` as `local_dict` argument.
-
-
-        Warning
-        -------
-        Blocks in `expr_config` must be ordered according to mutual dependency.
+        Examples
+        --------
+        >>> import lgdo
+        >>> tbl = lgdo.Table(
+        ...   col_dict={
+        ...     "a": lgdo.Array([1, 2, 3]),
+        ...     "b": lgdo.VectorOfVectors([[5], [6, 7], [8, 9, 0]]),
+        ...   }
+        ... )
+        >>> print(tbl.eval("a + b"))
+        [[6],
+         [8 9],
+         [11 12  3],
+        ]
+        >>> print(tbl.eval("np.sum(a) + ak.sum(b)"))
+        41
         """
-        out_tbl = Table(size=self.size)
-        for out_var, spec in expr_config.items():
-            in_vars = {}
-            # Find all valid python variables in expression (e.g "a*b+sin(Cool)" --> ['a','b','sin','Cool'])
-            for elem in re.findall(r"\s*[A-Za-z_]\w*\s*", spec["expression"]):
-                elem = elem.strip()
-                if elem in self:  # check if the variable comes from dsp
-                    in_vars[elem] = self[elem]
-                elif (
-                    elem in out_tbl.keys()
-                ):  # if not try from previously processed data, else ignore since it is e.g sin func
-                    in_vars[elem] = out_tbl[elem]
+        if parameters is None:
+            parameters = {}
 
+        # get the valid python variable names in the expression
+        c = compile(expr, "0vbb is real!", "eval")
+
+        # make a dictionary of low-level objects (numpy or awkward)
+        # for later computation
+        self_unwrap = {}
+        has_ak = False
+        for obj in c.co_names:
+            if obj in self.keys():
+                if isinstance(self[obj], VectorOfVectors):
+                    self_unwrap[obj] = self[obj].view_as("ak")
+                    has_ak = True
                 else:
-                    continue
-                # get the nda if it is an Array instance
-                if isinstance(in_vars[elem], Array):
-                    in_vars[elem] = in_vars[elem].nda
-                # No vector of vectors support yet
-                elif isinstance(in_vars[elem], VectorOfVectors):
-                    raise TypeError("Data of type VectorOfVectors not supported (yet)")
+                    self_unwrap[obj] = self[obj].view_as("np")
 
+        # use numexpr if we are only dealing with numpy data types
+        if not has_ak:
             out_data = ne.evaluate(
-                f"{spec['expression']}",
-                local_dict=dict(in_vars, **spec["parameters"])
-                if "parameters" in spec
-                else in_vars,
-            )  # Division is chosen by __future__.division in the interpreter
+                expr,
+                local_dict=(self_unwrap | parameters),
+            )
 
-            # smart way to find right LGDO data type:
-
-            # out_data has one row and this row has a scalar (eg scalar product of two rows)
-            if len(np.shape(out_data)) == 0:
-                out_data = Array(nda=out_data)
-
-            # out_data has scalar in each row
-            elif len(np.shape(out_data)) == 1:
-                out_data = Array(nda=out_data)
-
-            # out_data is  like
-            elif len(np.shape(out_data)) == 2:
-                out_data = ArrayOfEqualSizedArrays(nda=out_data)
-
-            # higher order data (eg matrix product of ArrayOfEqualSizedArrays) not supported yet
+            # need to convert back to LGDO
+            # np.evaluate should always return a numpy thing?
+            if out_data.ndim == 0:
+                return Scalar(out_data.item())
+            elif out_data.ndim == 1:
+                return Array(out_data)
+            elif out_data.ndim == 2:
+                return ArrayOfEqualSizedArrays(nda=out_data)
             else:
-                ValueError(
-                    f"Calculation resulted in {len(np.shape(out_data))-1}-D row which is not supported yet"
+                msg = (
+                    f"evaluation resulted in {out_data.ndim}-dimensional data, "
+                    "I don't know which LGDO this corresponds to"
                 )
+                raise RuntimeError(msg)
 
-            out_tbl.add_column(out_var, out_data)
+        else:
+            # resort to good ol' eval()
+            globs = {"ak": ak, "np": np}
+            out_data = eval(expr, globs, (self_unwrap | parameters))
 
-        return out_tbl
+            # need to convert back to LGDO
+            if isinstance(out_data, ak.Array):
+                if out_data.ndim == 1:
+                    return Array(out_data.to_numpy())
+                else:
+                    return VectorOfVectors(out_data)
+
+            if np.isscalar(out_data):
+                return Scalar(out_data)
+            else:
+                msg = (
+                    f"evaluation resulted in a {type(out_data)} object, "
+                    "I don't know which LGDO this corresponds to"
+                )
+                raise RuntimeError(msg)
 
     def __str__(self):
         opts = fmt.get_dataframe_repr_params()

--- a/tests/lh5/test_lh5_store.py
+++ b/tests/lh5/test_lh5_store.py
@@ -780,8 +780,8 @@ def test_write_object_overwrite_lgdo(caplog, tmptestdir):
     assert scalar_dat.value == 1
 
     # Finally, try overwriting a vector of vectors
-    vov1 = types.VectorOfVectors(listoflists=[np.zeros(1), np.ones(2), np.zeros(3)])
-    vov2 = types.VectorOfVectors(listoflists=[np.ones(1), np.zeros(2), np.ones(3)])
+    vov1 = types.VectorOfVectors([np.zeros(1), np.ones(2), np.zeros(3)])
+    vov2 = types.VectorOfVectors([np.ones(1), np.zeros(2), np.ones(3)])
     store = lh5.LH5Store()
     store.write(vov1, "my_vector", f"{tmptestdir}/write_object_overwrite_test.lh5")
     store.write(

--- a/tests/types/test_table_eval.py
+++ b/tests/types/test_table_eval.py
@@ -6,7 +6,7 @@ import lgdo
 def test_eval_dependency():
     obj = lgdo.Table(
         col_dict={
-            "a": lgdo.Array([1, 2, 3, 4]),
+            "a": lgdo.Array([1, 2, 3, 4], attrs={"units": "s"}),
             "b": lgdo.Array([5, 6, 7, 8]),
             "c": lgdo.ArrayOfEqualSizedArrays(
                 nda=[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]

--- a/tests/types/test_table_eval.py
+++ b/tests/types/test_table_eval.py
@@ -1,96 +1,62 @@
 import numpy as np
 
-from lgdo import Array, ArrayOfEqualSizedArrays, Table
+import lgdo
 
 
 def test_eval_dependency():
-    obj = Table(
+    obj = lgdo.Table(
         col_dict={
-            "a": Array(nda=np.array([1, 2, 3, 4], dtype=np.float32)),
-            "b": Array(nda=np.array([5, 6, 7, 8], dtype=np.float32)),
-            "c": ArrayOfEqualSizedArrays(
-                nda=np.array(
-                    [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]],
-                    dtype=np.float32,
-                )
+            "a": lgdo.Array([1, 2, 3, 4]),
+            "b": lgdo.Array([5, 6, 7, 8]),
+            "c": lgdo.ArrayOfEqualSizedArrays(
+                nda=[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]
             ),
-            "d": ArrayOfEqualSizedArrays(
-                nda=np.array(
-                    [
-                        [21, 22, 23, 24],
-                        [25, 26, 27, 8],
-                        [29, 210, 211, 212],
-                        [213, 214, 215, 216],
-                    ],
-                    dtype=np.float32,
-                )
+            "d": lgdo.ArrayOfEqualSizedArrays(
+                nda=[
+                    [21, 22, 23, 24],
+                    [25, 26, 27, 8],
+                    [29, 210, 211, 212],
+                    [213, 214, 215, 216],
+                ],
             ),
+            "e": lgdo.VectorOfVectors([[1, 2, 3], [4], [], [8, 6]]),
         }
     )
+    r = obj.eval("sum(a)")
+    assert isinstance(r, lgdo.Scalar)
 
-    expr_config = {
-        "O1": {"expression": "p1 + p2 * a**2", "parameters": {"p1": 2, "p2": 3}},
-        "O2": {"expression": "O1 - b"},
-        "O3": {"expression": "p1 + p2 * c", "parameters": {"p1": 2, "p2": 3}},
-        "O4": {"expression": "O3 - d", "parameters": {"p1": 2, "p2": 3}},
-        "O5": {"expression": "sum(c,axis=1)"},
-        "O6": {"expression": "a>p1", "parameters": {"p1": 2}},
-        "O7": {"expression": "c>p1", "parameters": {"p1": 2}},
-    }
+    r = obj.eval("a + b")
+    assert isinstance(r, lgdo.Array)
+    assert np.array_equal(r.nda, obj.a.nda + obj.b.nda)
 
-    out_tbl = obj.eval(expr_config)
-    assert list(out_tbl.keys()) == ["O1", "O2", "O3", "O4", "O5", "O6", "O7"]
-    assert (out_tbl["O1"].nda == [5, 14, 29, 50]).all()
-    assert (out_tbl["O2"].nda == [0, 8, 22, 42]).all()
-    assert (
-        out_tbl["O3"].nda
-        == [[5, 8, 11, 14], [17, 20, 23, 26], [29, 32, 35, 38], [41, 44, 47, 50]]
-    ).all()
-    assert (
-        out_tbl["O4"].nda
-        == [
-            [-16.0, -14.0, -12.0, -10.0],
-            [-8.0, -6.0, -4.0, 18.0],
-            [0.0, -178.0, -176.0, -174.0],
-            [-172.0, -170.0, -168.0, -166.0],
-        ]
-    ).all()
-    assert (out_tbl["O5"].nda == [10.0, 26.0, 42.0, 58.0]).all()
-    assert (out_tbl["O6"].nda == [False, False, True, True]).all()
-    assert (
-        out_tbl["O7"].nda
-        == [
-            [False, False, True, True],
-            [True, True, True, True],
-            [True, True, True, True],
-            [True, True, True, True],
-        ]
-    ).all()
+    r = obj.eval("((a - b) > 1) & ((b - a) < -1)")
+    assert isinstance(r, lgdo.Array)
+    assert r.dtype == "bool"
 
+    r = obj.eval("a + d")
+    assert isinstance(r, lgdo.ArrayOfEqualSizedArrays)
 
-def test_eval_math_functions():
-    obj = Table(
-        col_dict={
-            "a": Array(nda=np.array([1, 2, 3, 4], dtype=np.float32)),
-            "b": Array(nda=np.array([5, 6, 7, 8], dtype=np.float32)),
-            "c": ArrayOfEqualSizedArrays(
-                nda=np.array(
-                    [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]],
-                    dtype=np.float32,
-                )
-            ),
-        }
-    )
+    assert obj.eval("a**2")
+    assert obj.eval("sin(a)")
+    assert obj.eval("log(d)")
 
-    expr_config = {
-        "O1": {"expression": "exp(log(a))"},
-        "O2": {"expression": "exp(log(c))"},
-    }
+    r = obj.eval("a + e")
+    assert isinstance(r, lgdo.VectorOfVectors)
+    assert r == lgdo.VectorOfVectors([[2, 3, 4], [6], [], [12, 10]])
 
-    out_tbl = obj.eval(expr_config)
-    assert list(out_tbl.keys()) == ["O1", "O2"]
-    assert (out_tbl["O1"].nda == [1, 2, 3, 4]).all()
-    assert (
-        out_tbl["O2"].nda
-        == np.array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
-    ).all()
+    r = obj.eval("2*e + 1")
+    assert isinstance(r, lgdo.VectorOfVectors)
+    assert r == lgdo.VectorOfVectors([[3, 5, 7], [9], [], [17, 13]])
+
+    r = obj.eval("e > 2")
+    assert isinstance(r, lgdo.VectorOfVectors)
+    assert r == lgdo.VectorOfVectors([[False, False, True], [True], [], [True, True]])
+    assert r.dtype == "bool"
+
+    r = obj.eval("ak.sum(e, axis=-1)")
+    assert isinstance(r, lgdo.Array)
+
+    r = obj.eval("ak.sum(e)")
+    assert isinstance(r, lgdo.Scalar)
+
+    assert obj.eval("np.sum(a) + ak.sum(e)")

--- a/tests/types/test_vectorofvectors.py
+++ b/tests/types/test_vectorofvectors.py
@@ -48,6 +48,9 @@ def test_init(lgdo_vov):
     v = VectorOfVectors(shape_guess=(5, 0), dtype="int32")
     assert v.cumulative_length == lgdo.Array([0, 0, 0, 0, 0])
 
+    v = VectorOfVectors(ak.Array([[1, 2], [3, 4, 5], [2], [4, 8, 9, 7], [5, 3, 1]]))
+    assert v == test
+
 
 def test_datatype_name(lgdo_vov):
     assert lgdo_vov.datatype_name() == "array"


### PR DESCRIPTION
Re-implemented `Table.eval()`, now handles VectorOfVectors too!

Note: the signature is changed, `pygama.build_hit()` will need to be updated.

More details in the new docstring.

Also closes #5.