### PR TITLE
Deprecate `load_nda()` and `load_dfs()` in favour of `.view_as()`

### DIFF
--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -12,6 +12,7 @@ import sys
 from bisect import bisect_left
 from collections import defaultdict
 from typing import Any, Union
+from warnings import warn
 
 import h5py
 import numba as nb
@@ -1467,6 +1468,14 @@ def load_nda(
         Each entry contains the data for the specified parameter concatenated
         over all files in `f_list`.
     """
+    warn(
+        "load_nda() is deprecated. "
+        "Please replace it with LH5Store.read(...).view_as('np'). "
+        "load_nda() will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if isinstance(f_list, str):
         f_list = [f_list]
         if idx_list is not None:
@@ -1521,6 +1530,13 @@ def load_dfs(
         all data for the associated parameters concatenated over all files in
         `f_list`.
     """
+    warn(
+        "load_dfs() is deprecated. "
+        "Please replace it with LH5Store.read(...).view_as('pd'). "
+        "load_dfs() will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return pd.DataFrame(
         load_nda(f_list, par_list, lh5_group=lh5_group, idx_list=idx_list)
     )

--- a/tests/lh5/test_lh5_store.py
+++ b/tests/lh5/test_lh5_store.py
@@ -3,7 +3,6 @@ import os
 
 import h5py
 import numpy as np
-import pandas as pd
 import pytest
 
 import lgdo
@@ -67,21 +66,6 @@ def test_show(lgnd_file):
     lh5.show(lgnd_file)
     lh5.show(lgnd_file, "/geds/raw")
     lh5.show(lgnd_file, "geds/raw")
-
-
-def test_load_nda(lgnd_file):
-    nda = lh5.load_nda(
-        [lgnd_file, lgnd_file],
-        ["baseline", "waveform/values"],
-        lh5_group="/geds/raw",
-        idx_list=[[1, 3, 5], [2, 6, 7]],
-    )
-
-    assert isinstance(nda, dict)
-    assert isinstance(nda["baseline"], np.ndarray)
-    assert nda["baseline"].shape == (6,)
-    assert isinstance(nda["waveform/values"], np.ndarray)
-    assert nda["waveform/values"].shape == (6, 5592)
 
 
 @pytest.fixture(scope="module")
@@ -906,14 +890,3 @@ def test_write_object_append_column(tmptestdir):
     assert isinstance(tb_dat, types.Table)
     assert np.array_equal(tb_dat["dset1"].nda, np.zeros(10))
     assert np.array_equal(tb_dat["dset2"].nda, np.ones(10))
-
-
-def test_load_dfs(lgnd_file):
-    dfs = lh5.load_dfs(
-        [lgnd_file, lgnd_file],
-        ["baseline", "waveform/t0"],
-        lh5_group="/geds/raw",
-        idx_list=[[1, 3, 5], [2, 6, 7]],
-    )
-
-    assert isinstance(dfs, pd.DataFrame)


### PR DESCRIPTION
Just realized we forgot to do this.