### PR TITLE
Fix for reading just first row of VectorOfVectors

### DIFF
--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -417,11 +417,15 @@ class LH5Store:
 
         # Below here is all array-like types. So trim idx if needed
         if idx is not None:
-            # chop off indices < start_row
-            i_first_valid = bisect_left(idx[0], start_row)
-            idxa = idx[0][i_first_valid:]
-            # don't readout more than n_rows indices
-            idx = (idxa[:n_rows],)  # works even if n_rows > len(idxa)
+            # check if idx is just an ordered list of the integers if so can ignore
+            if (idx[0] == np.arange(0,len(idx[0]),1)).all():
+                idx = None
+            else:
+                # chop off indices < start_row
+                i_first_valid = bisect_left(idx[0], start_row)
+                idxa = idx[0][i_first_valid:]
+                # don't readout more than n_rows indices
+                idx = (idxa[:n_rows],)  # works even if n_rows > len(idxa)
 
         # Table or WaveformTable
         if datatype == "table":

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -418,7 +418,7 @@ class LH5Store:
         # Below here is all array-like types. So trim idx if needed
         if idx is not None:
             # check if idx is just an ordered list of the integers if so can ignore
-            if (idx[0] == np.arange(0,len(idx[0]),1)).all():
+            if (idx[0] == np.arange(0, len(idx[0]), 1)).all():
                 idx = None
             else:
                 # chop off indices < start_row

--- a/tests/lh5/test_lh5_store.py
+++ b/tests/lh5/test_lh5_store.py
@@ -245,7 +245,7 @@ def test_read_vov(lh5_file):
 
 def test_read_vov_fancy_idx(lh5_file):
     store = lh5.LH5Store()
-    
+
     lh5_obj, n_rows = store.read("/data/struct_full/vov", lh5_file, idx=[0], n_rows=1)
     assert isinstance(lh5_obj, types.VectorOfVectors)
 

--- a/tests/lh5/test_lh5_store.py
+++ b/tests/lh5/test_lh5_store.py
@@ -245,6 +245,10 @@ def test_read_vov(lh5_file):
 
 def test_read_vov_fancy_idx(lh5_file):
     store = lh5.LH5Store()
+    
+    lh5_obj, n_rows = store.read("/data/struct_full/vov", lh5_file, idx=[0], n_rows=1)
+    assert isinstance(lh5_obj, types.VectorOfVectors)
+
     lh5_obj, n_rows = store.read("/data/struct_full/vov", lh5_file, idx=[0, 2])
     assert isinstance(lh5_obj, types.VectorOfVectors)
 


### PR DESCRIPTION
 changed so if idx is ordered array of integers starting at 0 we just ignore, fixes #55 