### PR TITLE
Bug fix in `LH5Store.read()`: check for `n_rows` longer than `idx`s before dropping

### DIFF
--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -415,8 +415,8 @@ class LH5Store:
         if idx is not None:
             # check if idx is just an ordered list of the integers if so can ignore
             if (idx[0] == np.arange(0, len(idx[0]), 1)).all():
-                if n_rows > len(idx):
-                    n_rows = len(idx)
+                if n_rows > len(idx[0]):
+                    n_rows = len(idx[0])
                 idx = None
             else:
                 # chop off indices < start_row

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -415,6 +415,8 @@ class LH5Store:
         if idx is not None:
             # check if idx is just an ordered list of the integers if so can ignore
             if (idx[0] == np.arange(0, len(idx[0]), 1)).all():
+                if n_rows > len(idx):
+                    n_rows = len(idx)
                 idx = None
             else:
                 # chop off indices < start_row


### PR DESCRIPTION
Last pr could introduce unintended behaviour if user specifies n_rows longer than the idxs provided