### PR TITLE
`Table.view_as()` performance fixes

### DIFF
--- a/src/lgdo/logging.py
+++ b/src/lgdo/logging.py
@@ -16,7 +16,7 @@ CRITICAL = logging.CRITICAL
 def setup(level: int = logging.INFO, logger: logging.Logger | None = None) -> None:
     """Setup a colorful logging output.
 
-    If `logger` is None, sets up only the ``pygama`` logger.
+    If `logger` is None, sets up only the ``lgdo`` logger.
 
     Parameters
     ----------
@@ -27,7 +27,7 @@ def setup(level: int = logging.INFO, logger: logging.Logger | None = None) -> No
 
     Examples
     --------
-    >>> from pygama import logging
+    >>> from lgdo import logging
     >>> logging.setup(level=logging.DEBUG)
     """
     handler = colorlog.StreamHandler()
@@ -36,7 +36,7 @@ def setup(level: int = logging.INFO, logger: logging.Logger | None = None) -> No
     )
 
     if logger is None:
-        logger = colorlog.getLogger("pygama")
+        logger = colorlog.getLogger("lgdo")
 
     logger.setLevel(level)
     logger.addHandler(handler)

--- a/src/lgdo/types/array.py
+++ b/src/lgdo/types/array.py
@@ -182,6 +182,7 @@ class Array(LGDO):
             if self.nda.ndim == 1:
                 return pd.Series(self.nda, copy=False)
 
+            # if array is multi-dim, use awkward
             return akpd.from_awkward(self.view_as("ak"))
 
         if library == "np":

--- a/src/lgdo/types/array.py
+++ b/src/lgdo/types/array.py
@@ -196,6 +196,7 @@ class Array(LGDO):
                 msg = "Pint does not support Awkward yet, you must view the data with_units=False"
                 raise ValueError(msg)
 
+            # NOTE: this is zero-copy!
             return ak.Array(self.nda)
 
         msg = f"{library} is not a supported third-party format."

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -391,11 +391,11 @@ class Table(Struct):
         --------
         .LGDO.view_as
         """
+        if cols is None:
+            cols = self.keys()
+
         if library == "pd":
             df = pd.DataFrame()
-
-            if cols is None:
-                cols = self.keys()
 
             for col in cols:
                 data = self[col]
@@ -426,7 +426,10 @@ class Table(Struct):
                 msg = "Pint does not support Awkward yet, you must view the data with_units=False"
                 raise ValueError(msg)
 
-            return ak.Array(self)
+            # NOTE: passing the Table directly (which inherits from a dict)
+            # makes it somehow really slow. Not sure why, but this could be due
+            # to extra LGDO fields (like "attrs")
+            return ak.Array({col: self[col].view_as("ak") for col in cols})
 
         msg = f"{library!r} is not a supported third-party format."
         raise TypeError(msg)


### PR DESCRIPTION
- Fix logging module
- Make `Table.view_as("pd")` faster by avoiding copies
- Fix for `Table.view_as("ak")`: now it's really fast
