### PR TITLE
Supplement how attributes are stored to improve data loading speed by x2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ test = [
 [project.scripts]
 lh5ls = "lgdo.cli:lh5ls"
 lh5concat = "lgdo.cli:lh5concat"
+lh5meta = "lgdo.cli:lh5meta"
 
 [tool.setuptools]
 include-package-data = true

--- a/src/lgdo/cli.py
+++ b/src/lgdo/cli.py
@@ -10,6 +10,7 @@ import sys
 
 from . import Array, Table, VectorOfVectors, __version__, lh5
 from . import logging as lgdogging  # eheheh
+from .lh5.utils import get_metadata
 
 log = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ def lh5ls(args=None):
     )
     parser.add_argument("lh5_group", nargs="?", help="""LH5 group.""", default="/")
     parser.add_argument(
-        "--attributes", "-a", action="store_true", help="""Print HDF5 attributes too"""
+        "--attributes", "-a", "--attrs", action="store_true", help="""Print HDF5 attributes too"""
     )
     parser.add_argument(
         "--depth",
@@ -203,6 +204,9 @@ Exclude the /data/table1/col1 Table column:
     else:
         obj_list = obj_list_full
 
+    # remove metadata if it exists - do not attempt to concatenate this
+    obj_list.discard("metadata")
+
     # sort
     obj_list = sorted(obj_list)
 
@@ -299,6 +303,11 @@ Exclude the /data/table1/col1 Table column:
                 _inplace_table_filter(name, obj, obj_list)
 
             store.write(obj, name, args.output, wo_mode="append")
+
+    # write the metadata for the new file at the very end
+    store.write_metadata(args.output)
+
+    return
 
 def lh5meta(args=None):
     """Re-builds `metadata"` `Dataset` for an LH5 file or list of files."""

--- a/src/lgdo/cli.py
+++ b/src/lgdo/cli.py
@@ -301,9 +301,9 @@ Exclude the /data/table1/col1 Table column:
             store.write(obj, name, args.output, wo_mode="append")
 
 def lh5meta(args=None):
-    """Re-builds `metadata"` `Dataset` for an LH5 file."""
+    """Re-builds `metadata"` `Dataset` for an LH5 file or list of files."""
     parser = argparse.ArgumentParser(
-        prog="lh5meta", description="re-builds `'metadata'` `Dataset` for an LH5 file."
+        prog="lh5meta", description="re-builds `'metadata'` `Dataset` for an LH5 file or list of files."
     )   
 
     # global options

--- a/src/lgdo/cli.py
+++ b/src/lgdo/cli.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
-import h5py
 import logging
 import sys
 
 from . import Array, Table, VectorOfVectors, __version__, lh5
 from . import logging as lgdogging  # eheheh
-from .lh5.utils import get_metadata
 
 log = logging.getLogger(__name__)
 
@@ -45,7 +43,11 @@ def lh5ls(args=None):
     )
     parser.add_argument("lh5_group", nargs="?", help="""LH5 group.""", default="/")
     parser.add_argument(
-        "--attributes", "-a", "--attrs", action="store_true", help="""Print HDF5 attributes too"""
+        "--attributes",
+        "-a",
+        "--attrs",
+        action="store_true",
+        help="""Print HDF5 attributes too""",
     )
     parser.add_argument(
         "--depth",
@@ -307,13 +309,13 @@ Exclude the /data/table1/col1 Table column:
     # write the metadata for the new file at the very end
     store.write_metadata(args.output)
 
-    return
 
 def lh5meta(args=None):
     """Re-builds `metadata"` `Dataset` for an LH5 file or list of files."""
     parser = argparse.ArgumentParser(
-        prog="lh5meta", description="re-builds `'metadata'` `Dataset` for an LH5 file or list of files."
-    )   
+        prog="lh5meta",
+        description="re-builds `'metadata'` `Dataset` for an LH5 file or list of files.",
+    )
 
     # global options
     parser.add_argument(
@@ -334,12 +336,12 @@ def lh5meta(args=None):
     )
 
     parser.add_argument(
-    "lh5_file",
-    nargs="+",
-    help="""Input list LH5 files""",
-    )  
+        "lh5_file",
+        nargs="+",
+        help="""Input list LH5 files""",
+    )
 
-    args = parser.parse_args(args) 
+    args = parser.parse_args(args)
 
     if args.verbose:
         lgdogging.setup(logging.DEBUG)
@@ -347,12 +349,10 @@ def lh5meta(args=None):
         lgdogging.setup(logging.DEBUG, logging.root)
     else:
         lgdogging.setup()
-    
+
     if args.version:
         print(__version__)  # noqa: T201
         sys.exit()
 
     store = lh5.LH5Store()
     store.write_metadata(args.lh5_file)
-    
-    return

--- a/src/lgdo/cli.py
+++ b/src/lgdo/cli.py
@@ -303,7 +303,7 @@ Exclude the /data/table1/col1 Table column:
 def lh5meta(args=None):
     """Re-builds `metadata"` `Dataset` for an LH5 file."""
     parser = argparse.ArgumentParser(
-        prog="makemetadata", description="re-builds `'metadata'` `Dataset` for an LH5 file."
+        prog="lh5meta", description="re-builds `'metadata'` `Dataset` for an LH5 file."
     )   
 
     # global options
@@ -326,7 +326,8 @@ def lh5meta(args=None):
 
     parser.add_argument(
     "lh5_file",
-    help="""Input LH5 file""",
+    nargs="+",
+    help="""Input list LH5 files""",
     )  
 
     args = parser.parse_args(args) 

--- a/src/lgdo/cli.py
+++ b/src/lgdo/cli.py
@@ -342,12 +342,7 @@ def lh5meta(args=None):
         print(__version__)  # noqa: T201
         sys.exit()
 
-    with h5py.File(args.lh5_file, mode='a') as f:
-        if 'metadata' in f:
-            del f['metadata']
-        metadata = lh5.utils.get_metadata(lh5_file=args.lh5_file, force=True)
-        jsontowrite = str(metadata).replace("'", "\"")
-        f.create_dataset(f'metadata', dtype=f'S{len(str(jsontowrite))}', data=str(jsontowrite))
-        f['metadata'].attrs['datatype'] = 'JSON'
+    store = lh5.LH5Store()
+    store.write_metadata(args.lh5_file)
     
     return

--- a/src/lgdo/lh5/_serializers/read/composite.py
+++ b/src/lgdo/lh5/_serializers/read/composite.py
@@ -23,7 +23,6 @@ from ....types import (
 from ... import datatype as dtypeutils
 from ...exceptions import LH5DecodeError
 
-# from ...utils import read_n_rows, getFromDict
 from . import utils
 from .array import (
     _h5_read_array,

--- a/src/lgdo/lh5/_serializers/read/composite.py
+++ b/src/lgdo/lh5/_serializers/read/composite.py
@@ -22,6 +22,7 @@ from ....types import (
 )
 from ... import datatype as dtypeutils
 from ...exceptions import LH5DecodeError
+
 # from ...utils import read_n_rows, getFromDict
 from . import utils
 from .array import (
@@ -50,9 +51,8 @@ def _h5_read_lgdo(
     obj_buf=None,
     obj_buf_start=0,
     decompress=True,
-    metadata=None, # dict
+    metadata=None,  # dict
 ):
-
     if not isinstance(h5f, h5py.File):
         h5f = h5py.File(h5f, mode="r")
 
@@ -65,14 +65,11 @@ def _h5_read_lgdo(
     if not (isinstance(idx, tuple) and len(idx) == 1) and idx is not None:
         idx = (idx,)
 
-
     # this needs to be done for the requested object
     if metadata is not None:
         try:
-            lgdotype = dtypeutils.datatype(metadata['attrs']["datatype"])
-            log.debug(
-                f"{name}.attrs.datatype found in metadata"
-            )
+            lgdotype = dtypeutils.datatype(metadata["attrs"]["datatype"])
+            log.debug(f"{name}.attrs.datatype found in metadata")
         except KeyError as e:
             log.debug(
                 f"metadata key error in {h5f.filename}: {e} - will attempt to use file directly instead"

--- a/src/lgdo/lh5/_serializers/read/composite.py
+++ b/src/lgdo/lh5/_serializers/read/composite.py
@@ -52,57 +52,6 @@ def _h5_read_lgdo(
     decompress=True,
     metadata=None, # dict
 ):
-    # # Handle list-of-files recursively
-    # if not isinstance(h5f, (str, h5py.File)):
-    #     lh5_file = list(h5f)
-    #     n_rows_read = 0
-
-    #     for i, h5f in enumerate(lh5_file):
-    #         if isinstance(idx, list) and len(idx) > 0 and not np.isscalar(idx[0]):
-    #             # a list of lists: must be one per file
-    #             idx_i = idx[i]
-    #         elif idx is not None:
-    #             # make idx a proper tuple if it's not one already
-    #             if not (isinstance(idx, tuple) and len(idx) == 1):
-    #                 idx = (idx,)
-    #             # idx is a long continuous array
-    #             n_rows_i = read_n_rows(name, h5f)
-    #             # find the length of the subset of idx that contains indices
-    #             # that are less than n_rows_i
-    #             n_rows_to_read_i = bisect.bisect_left(idx[0], n_rows_i)
-    #             # now split idx into idx_i and the remainder
-    #             idx_i = (idx[0][:n_rows_to_read_i],)
-    #             idx = (idx[0][n_rows_to_read_i:] - n_rows_i,)
-    #         else:
-    #             idx_i = None
-    #         n_rows_i = n_rows - n_rows_read
-
-    #         metadata = load_metadata(h5f) 
-    #         # just get the relevant subset of metadata now
-    #         if metadata is not None:
-    #             metadata = getFromDict(metadata, list(filter(None, name.strip('/').split('/'))))            
-
-    #         obj_buf, n_rows_read_i = _h5_read_lgdo(
-    #             name,
-    #             h5f,
-    #             start_row=start_row,
-    #             n_rows=n_rows_i,
-    #             idx=idx_i,
-    #             use_h5idx=use_h5idx,
-    #             field_mask=field_mask,
-    #             obj_buf=obj_buf,
-    #             obj_buf_start=obj_buf_start,
-    #             decompress=decompress,
-    #             metadata=metadata,
-    #         )
-
-    #         n_rows_read += n_rows_read_i
-    #         if n_rows_read >= n_rows or obj_buf is None:
-    #             return obj_buf, n_rows_read
-    #         start_row = 0
-    #         obj_buf_start += n_rows_read_i
-
-    #     return obj_buf, n_rows_read
 
     if not isinstance(h5f, h5py.File):
         h5f = h5py.File(h5f, mode="r")

--- a/src/lgdo/lh5/_serializers/read/ndarray.py
+++ b/src/lgdo/lh5/_serializers/read/ndarray.py
@@ -22,6 +22,7 @@ def _h5_read_ndarray(
     use_h5idx=False,
     obj_buf=None,
     obj_buf_start=0,
+    metadata=None,
 ):
     if obj_buf is not None and not isinstance(obj_buf, Array):
         msg = "object buffer is not an Array"
@@ -94,7 +95,10 @@ def _h5_read_ndarray(
         nda = h5f[name][...][source_sel]
 
     # Finally, set attributes and return objects
-    attrs = h5f[name].attrs
+    if metadata is not None:
+        attrs = metadata["attrs"]
+    else:
+        attrs = h5f[name].attrs
 
     # special handling for bools
     # (c and Julia store as uint8 so cast to bool)

--- a/src/lgdo/lh5/_serializers/read/scalar.py
+++ b/src/lgdo/lh5/_serializers/read/scalar.py
@@ -14,7 +14,7 @@ def _h5_read_scalar(
     name,
     h5f,
     obj_buf=None,
-    metadata=None, # specific to requested object
+    metadata=None,  # specific to requested object
 ):
     value = h5f[name][()]
 
@@ -42,5 +42,5 @@ def _h5_read_scalar(
     if frommeta:
         thisattrs = metadata["attrs"]
     else:
-        thisattrs = h5f[name].attrs 
+        thisattrs = h5f[name].attrs
     return Scalar(value=value, attrs=thisattrs), 1

--- a/src/lgdo/lh5/_serializers/read/scalar.py
+++ b/src/lgdo/lh5/_serializers/read/scalar.py
@@ -14,12 +14,17 @@ def _h5_read_scalar(
     name,
     h5f,
     obj_buf=None,
+    metadata=None, # specific to requested object
 ):
     value = h5f[name][()]
 
+    frommeta = False
+    if metadata is not None:
+        frommeta = metadata["attrs"]["datatype"] == "bool"
+
     # special handling for bools
     # (c and Julia store as uint8 so cast to bool)
-    if h5f[name].attrs["datatype"] == "bool":
+    if frommeta or h5f[name].attrs["datatype"] == "bool":
         value = np.bool_(value)
 
     if obj_buf is not None:
@@ -28,7 +33,14 @@ def _h5_read_scalar(
             raise LH5DecodeError(msg, h5f, name)
 
         obj_buf.value = value
-        obj_buf.attrs.update(h5f[name].attrs)
+        if frommeta:
+            obj_buf.attrs.update(metadata["attrs"])
+        else:
+            obj_buf.attrs.update(h5f[name].attrs)
         return obj_buf, 1
 
-    return Scalar(value=value, attrs=h5f[name].attrs), 1
+    if frommeta:
+        thisattrs = metadata["attrs"]
+    else:
+        thisattrs = h5f[name].attrs 
+    return Scalar(value=value, attrs=thisattrs), 1

--- a/src/lgdo/lh5/_serializers/write/scalar.py
+++ b/src/lgdo/lh5/_serializers/write/scalar.py
@@ -9,10 +9,10 @@ log = logging.getLogger(__name__)
 
 
 def _h5_write_scalar(
-    obj, 
-    name, 
-    lh5_file, 
-    group="/", 
+    obj,
+    name,
+    lh5_file,
+    group="/",
     wo_mode="append",
 ) -> None:
     assert isinstance(obj, types.Scalar)

--- a/src/lgdo/lh5/_serializers/write/scalar.py
+++ b/src/lgdo/lh5/_serializers/write/scalar.py
@@ -8,7 +8,13 @@ from ...exceptions import LH5EncodeError
 log = logging.getLogger(__name__)
 
 
-def _h5_write_scalar(obj, name, lh5_file, group="/", wo_mode="append"):
+def _h5_write_scalar(
+    obj, 
+    name, 
+    lh5_file, 
+    group="/", 
+    wo_mode="append",
+) -> None:
     assert isinstance(obj, types.Scalar)
 
     if name in group:

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -9,8 +9,8 @@ import h5py
 from numpy.typing import ArrayLike
 
 from .. import types
-from . import _serializers
-from . import utils
+from . import _serializers, utils
+
 
 def read(
     name: str,
@@ -100,8 +100,8 @@ def read(
         built-in filters, which is always decompressed upstream by HDF5.
     use_metadata
         Whether to use the `"metadata"` dataset if it exists in the file.
-        This special dataset will generally reduce data loading times if 
-        you are getting several (>~12) datasets (columns) from a file. 
+        This special dataset will generally reduce data loading times if
+        you are getting several (>~12) datasets (columns) from a file.
 
     Returns
     -------
@@ -116,7 +116,7 @@ def read(
     metadata = None
     if use_metadata:
         metadata = utils.get_metadata(lh5_file=lh5_file)
-        
+
     obj, n_rows_read = _serializers._h5_read_lgdo(
         name,
         lh5_file,

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -13,6 +13,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 import h5py
+import json
 import numpy as np
 from numpy.typing import ArrayLike
 
@@ -307,7 +308,7 @@ class LH5Store:
             metadata = utils.get_metadata(lh5_file=lh5_file, force=True)
 
             # write the metadata as a JSON string
-            jsontowrite = str(metadata).replace("'", '"')
+            jsontowrite = json.dumps(metadata)
             lh5_file.create_dataset(
                 "metadata", dtype=f"S{len(str(jsontowrite))}", data=str(jsontowrite)
             )

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -5,7 +5,9 @@ HDF5 files.
 
 from __future__ import annotations
 
+import bisect
 import logging
+import numpy as np
 import os
 import sys
 from collections.abc import Mapping, Sequence
@@ -34,7 +36,12 @@ class LH5Store:
     lgdo.waveformtable.WaveformTable
     """
 
-    def __init__(self, base_path: str = "", keep_open: bool = False) -> None:
+    def __init__(
+        self, 
+        base_path: str = "", 
+        keep_open: bool = False, 
+        metacachesize: int = 100,
+    ) -> None:
         """
         Parameters
         ----------
@@ -43,10 +50,14 @@ class LH5Store:
         keep_open
             whether to keep files open by storing the :mod:`h5py` objects as
             class attributes.
+        metacache
+            maximum size for metadata cache, default is 100 MB (specify in units of MB)
         """
         self.base_path = "" if base_path == "" else utils.expand_path(base_path)
         self.keep_open = keep_open
         self.files = {}
+        self.metadata_cache = {}
+        self.metacachesize = int(metacachesize * 1E6)
 
     def gimme_file(self, lh5_file: str | h5py.File, mode: str = "r") -> h5py.File:
         """Returns a :mod:`h5py` file object from the store or creates a new one.
@@ -142,12 +153,72 @@ class LH5Store:
         --------
         .lh5.core.read
         """
+        metadata = None
+
         # grab files from store
         if not isinstance(lh5_file, (str, h5py.File)):
             lh5_file = [self.gimme_file(f, "r") for f in list(lh5_file)]
         else:
             lh5_file = self.gimme_file(lh5_file, "r")
+            metadata = self.load_metadata(lh5_file, name) 
+            # # just get the relevant subset of metadata now
+            # if metadata is not None:
+            #     metadata = utils.getFromDict(metadata, list(filter(None, name.strip('/').split('/'))))
 
+        h5f = lh5_file
+        # Handle list-of-files recursively - how about no?
+        if not isinstance(h5f, (str, h5py.File)):
+            thislh5_file = list(h5f)
+            n_rows_read = 0
+
+            for i, h5f in enumerate(thislh5_file):
+                if isinstance(idx, list) and len(idx) > 0 and not np.isscalar(idx[0]):
+                    # a list of lists: must be one per file
+                    idx_i = idx[i]
+                elif idx is not None:
+                    # make idx a proper tuple if it's not one already
+                    if not (isinstance(idx, tuple) and len(idx) == 1):
+                        idx = (idx,)
+                    # idx is a long continuous array
+                    n_rows_i = utils.read_n_rows(name, h5f)
+                    # find the length of the subset of idx that contains indices
+                    # that are less than n_rows_i
+                    n_rows_to_read_i = bisect.bisect_left(idx[0], n_rows_i)
+                    # now split idx into idx_i and the remainder
+                    idx_i = (idx[0][:n_rows_to_read_i],)
+                    idx = (idx[0][n_rows_to_read_i:] - n_rows_i,)
+                else:
+                    idx_i = None
+                n_rows_i = n_rows - n_rows_read
+
+                metadata = self.load_metadata(h5f, name) 
+
+                # # just get the relevant subset of metadata now
+                # if metadata is not None:
+                #     metadata = utils.getFromDict(metadata, list(filter(None, name.strip('/').split('/'))))
+                    
+                obj_buf, n_rows_read_i = _serializers._h5_read_lgdo(
+                    name,
+                    h5f,
+                    start_row=start_row,
+                    n_rows=n_rows_i,
+                    idx=idx_i,
+                    use_h5idx=use_h5idx,
+                    field_mask=field_mask,
+                    obj_buf=obj_buf,
+                    obj_buf_start=obj_buf_start,
+                    decompress=decompress,
+                    metadata=metadata,
+                )
+
+                n_rows_read += n_rows_read_i
+                if n_rows_read >= n_rows or obj_buf is None:
+                    return obj_buf, n_rows_read
+                start_row = 0
+                obj_buf_start += n_rows_read_i
+            
+            return obj_buf, n_rows_read
+                
         return _serializers._h5_read_lgdo(
             name,
             lh5_file,
@@ -159,6 +230,7 @@ class LH5Store:
             obj_buf=obj_buf,
             obj_buf_start=obj_buf_start,
             decompress=decompress,
+            metadata=metadata,
         )
 
     def write(
@@ -218,3 +290,53 @@ class LH5Store:
         Return ``None`` if it is a :class:`.Scalar` or a :class:`.Struct`.
         """
         return utils.read_n_rows(name, self.gimme_file(lh5_file, "r"))
+
+    def load_metadata(
+        self,
+        lh5_file: h5py.File,
+        name: str,
+    )-> dict:
+        """Gets metadata dataset from the store if it exists or else from the file. Returns None if metadata is not
+        found in the file."""
+        metadata = None
+
+        if lh5_file.filename not in self.metadata_cache:
+            # don't want to build the metadata because this is slow if you only want to grab a few datasets
+            metadata = utils.get_metadata(lh5_file, build=False)
+            # it is possible that someone could read a file, then want to write to it, then read it again using the
+            # same store instance. If we keep the metadata from before the file were updated, we would not find some 
+            # newly written information. On the other hand, the redunancy is built into the reading so that if 
+            # something is not found in the metadata, it is looked for in the attributes of the file directly.
+            # Let us stick with the slightly faster way if someone does not want to or think to set the keep_open 
+            # flag to True. All that needs to be added here is: 
+            # if self.keep_open:
+            self.metadata_cache[lh5_file.filename] = metadata
+            # clear the cache if we write something so it is not too big
+            self.clear_metadata_cache()
+        else:
+            metadata = self.metadata_cache[lh5_file.filename]
+
+        if metadata is not None:
+            metadata = utils.getFromDict(metadata, list(filter(None, name.strip('/').split('/'))))
+                    
+        return metadata
+
+    def clear_metadata_cache(
+        self
+    ) -> None:
+        """Removes entries from the metadata cache if the size is too large. Keeps at least one file in the cache
+        regardless of its size. Default maximum size is 100 MB (specify `maxsize` in MB)."""
+        if len(self.metadata_cache) > 1 and (
+            metadatasize := utils.getsize(self.metadata_cache)) > self.metacachesize:
+            log.debug(
+                f"metadata cache is {utils.fmtbytes(metadatasize)}, larger than max size of "
+                f"{utils.fmtbytes(self.metacachesize)}, deleting entries to reduce size"
+            )
+            # in order of how the files were added to the metadata (so presumably the access order)
+            files = list(self.metadata_cache.keys())
+            while len(self.metadata_cache) > 0 and (utils.getsize(self.metadata_cache) > self.metacachesize):
+                for file in files:
+                    del self.metadata_cache[file]
+
+        return
+            

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -283,7 +283,7 @@ class LH5Store:
     def write_metadata(
         self,
         lh5_file: str | h5py.File | list,
-    ) -> dict:
+    ) -> None:
         """Writes the `"metadata"` dataset to an LH5 file. Gathers the metadata from the file and writes it.
         Overwrites any existing `"metadata"` dataset. Takes an LH5 file, path to file, or list of either.
 
@@ -316,7 +316,7 @@ class LH5Store:
                 f"wrote metadata to {lh5_file.filename}"
             )   
 
-        return metadata
+        return 
 
     def read_n_rows(
         self, 

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -161,9 +161,6 @@ class LH5Store:
         else:
             lh5_file = self.gimme_file(lh5_file, "r")
             metadata = self.load_metadata(lh5_file, name) 
-            # # just get the relevant subset of metadata now
-            # if metadata is not None:
-            #     metadata = utils.getFromDict(metadata, list(filter(None, name.strip('/').split('/'))))
 
         h5f = lh5_file
         # Handle list-of-files recursively - how about no?

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -166,7 +166,6 @@ class LH5Store:
                 metadata = self.load_metadata(lh5_file, name)
 
         h5f = lh5_file
-        # Handle list-of-files recursively - how about no?
         if not isinstance(h5f, (str, h5py.File)):
             thislh5_file = list(h5f)
             n_rows_read = 0

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -298,7 +298,10 @@ class LH5Store:
             # delete the old metadata if it exists
             if "metadata" in lh5_file:
                 del lh5_file["metadata"]
-            
+                log.debug(
+                    f"deleted old metadata from {lh5_file.filename}"
+                )    
+
             # get the new metadata from the file
             metadata = utils.get_metadata(lh5_file=lh5_file, force=True)
 
@@ -306,6 +309,9 @@ class LH5Store:
             jsontowrite = str(metadata).replace("'", "\"")
             lh5_file.create_dataset(f'metadata', dtype=f'S{len(str(jsontowrite))}', data=str(jsontowrite))
             lh5_file['metadata'].attrs['datatype'] = 'JSON'
+            log.debug(
+                f"wrote metadata to {lh5_file.filename}"
+            )   
 
         return None
 

--- a/src/lgdo/lh5/tools.py
+++ b/src/lgdo/lh5/tools.py
@@ -189,6 +189,20 @@ def show(
                     toprint += f", \033[3mnumchunks\033[0m={val.id.get_num_chunks()}"
                     toprint += f", \033[3mchunkshape\033[0m={chunkshape}"
                 toprint += f", \033[3mcompression\033[0m={val.compression}"
+                toprint += f", \033[3mfilters\033[0m="
+
+                numfilters = val.id.get_create_plist().get_nfilters()
+                if numfilters == 0:
+                    toprint += 'None'
+                else:
+                    toprint += '('
+                    for i in range(numfilters):
+                        thisfilter = val.id.get_create_plist().get_filter(i)[3].decode()
+                        if 'lz4' in thisfilter:
+                            thisfilter = 'lz4'
+                        toprint += f"{thisfilter},"
+                    toprint += ')'
+
             except TypeError:
                 toprint += "(scalar)"
 

--- a/src/lgdo/lh5/tools.py
+++ b/src/lgdo/lh5/tools.py
@@ -188,7 +188,6 @@ def show(
                 else:
                     toprint += f", \033[3mnumchunks\033[0m={val.id.get_num_chunks()}"
                     toprint += f", \033[3mchunkshape\033[0m={chunkshape}"
-                toprint += f", \033[3mcompression\033[0m={val.compression}"
                 toprint += f", \033[3mfilters\033[0m="
 
                 numfilters = val.id.get_create_plist().get_nfilters()

--- a/src/lgdo/lh5/tools.py
+++ b/src/lgdo/lh5/tools.py
@@ -188,19 +188,19 @@ def show(
                 else:
                     toprint += f", \033[3mnumchunks\033[0m={val.id.get_num_chunks()}"
                     toprint += f", \033[3mchunkshape\033[0m={chunkshape}"
-                toprint += f", \033[3mfilters\033[0m="
+                toprint += ", \033[3mfilters\033[0m="
 
                 numfilters = val.id.get_create_plist().get_nfilters()
                 if numfilters == 0:
-                    toprint += 'None'
+                    toprint += "None"
                 else:
-                    toprint += '('
+                    toprint += "("
                     for i in range(numfilters):
                         thisfilter = val.id.get_create_plist().get_filter(i)[3].decode()
-                        if 'lz4' in thisfilter:
-                            thisfilter = 'lz4'
+                        if "lz4" in thisfilter:
+                            thisfilter = "lz4"
                         toprint += f"{thisfilter},"
-                    toprint += ')'
+                    toprint += ")"
 
             except TypeError:
                 toprint += "(scalar)"

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -323,7 +323,15 @@ def get_metadata(
 
     # open file
     if isinstance(lh5_file, str):
-        lh5_file = h5py.File(expand_path(lh5_file), "r")
+        # expand_path gives an error if file does not exist
+        try: 
+            fullpath = expand_path(lh5_file)
+        except FileNotFoundError:
+            log.debug(
+                f"{lh5_file} does not exist, metadata is None"
+            )
+            return None
+        lh5_file = h5py.File(fullpath, "r")
 
     # looks for "metadata" dataset and uses it if it exists
     # or you can force it to loop over the file to build it instead

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -30,7 +30,6 @@ from .exceptions import LH5DecodeError
 
 log = logging.getLogger(__name__)
 
-
 def get_buffer(
     name: str,
     lh5_file: str | h5py.File | Sequence[str | h5py.File],
@@ -347,6 +346,11 @@ def get_metadata(
                 f"metadata not found in {lh5_file.filename}, building it instead"
             )
         for obj in lh5_file:
+            # if "metadata" actually was in the file and was missed due to forcing a rebuild, then the metadata
+            # from the old file could be dragged along and updated and have outdated stuff in it
+            if obj == 'metadata':
+                pass
+
             metadata[obj] = {}
 
             metadata[obj]['attrs'] = {}
@@ -357,7 +361,7 @@ def get_metadata(
                 get_metadata(lh5_file[base+obj], metadata=metadata[obj], base=base+obj+'/', build=True, recursing=True)
     else:
         log.debug(
-            f"metadata not found in {lh5_file.filename} and did not build it"
+            f"metadata not found in {lh5_file.filename} and did not build it -> metadata is None"
         )
         return None
         

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -293,7 +293,7 @@ def getsize(obj):
 # function is recursive
 def get_metadata(
     lh5_file: str | h5py.Group | h5py.File,
-    build: bool = True,
+    build: bool = False,
     force: bool = False,
     metadata: dict = {}, 
     base: str = "/", 
@@ -315,7 +315,7 @@ def get_metadata(
     lh5_file
         path to an `LH5` file
     build
-        whether to build the metadata from the file if the `"metadata"` `Dataset` is not found; default is `True`
+        whether to build the metadata from the file if the `"metadata"` `Dataset` is not found; default is `False`
     force
         whether to ignore the `"metadata"` `Dataset` and build a `dict` from the file instead; default is `False`. 
         Ignores the `build` flag.
@@ -348,6 +348,7 @@ def get_metadata(
         for obj in lh5_file:
             # if "metadata" actually was in the file and was missed due to forcing a rebuild, then the metadata
             # from the old file could be dragged along and updated and have outdated stuff in it
+            # not 100% sure this is needed
             if obj == 'metadata':
                 pass
 
@@ -364,5 +365,9 @@ def get_metadata(
             f"metadata not found in {lh5_file.filename} and did not build it -> metadata is None"
         )
         return None
+    
+    # know thyself!
+    if not recursing:
+        metadata["metadata"] = {'attrs': {'datatype': 'JSON'}}
         
     return metadata

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import numpy as np
 import h5py
+import numpy as np
 
 from lgdo import cli, lh5, types
 
@@ -156,6 +156,7 @@ def test_lh5concat(lgnd_test_data, tmptestdir):
         assert np.array_equal(tbl.tracelist[i], tbl2.tracelist[i - 10])
         assert np.array_equal(tbl.waveform.values[i], tbl2.waveform.values[i - 10])
 
+
 def test_lh5meta(lgnd_test_data, tmptestdir):
     file = lgnd_test_data.get_path(
         "lh5/prod-ref-l200/generated/tier/raw/phy/p03/r001/l200-p03-r001-phy-20230322T160139Z-tier_raw.lh5"
@@ -174,13 +175,17 @@ def test_lh5meta(lgnd_test_data, tmptestdir):
         "ch1121600",
         "metadata",
     ]
-    
+
     store = lh5.LH5Store(metacachesize=0)
     tbl1, size = store.read("ch1057600/raw", file)
     assert size == 10
-    assert store.metadata_cache[file]["metadata"] == lh5.utils.get_metadata(file, force=True)
+    assert store.metadata_cache[file]["metadata"] == lh5.utils.get_metadata(
+        file, force=True
+    )
 
-    assert store.read_n_rows("ch1057600/raw", file, metadata=None, use_metadata=True) == 10
+    assert (
+        store.read_n_rows("ch1057600/raw", file, metadata=None, use_metadata=True) == 10
+    )
 
     tbl2, size = store.read("ch1057600/raw", file, use_metadata=False)
     assert size == 10
@@ -188,13 +193,15 @@ def test_lh5meta(lgnd_test_data, tmptestdir):
 
     store.clear_metadata_cache(force=True)
     assert store.metadata_cache == {}
-    
-    with h5py.File(file, 'a') as f:
-        del f['metadata']
-        metadata = {'badmetadata':'bad'}
-        jsontowrite = str(metadata).replace("'", "\"")
-        f.create_dataset(f'metadata', dtype=f'S{len(str(jsontowrite))}', data=str(jsontowrite))
-        f['metadata'].attrs['datatype'] = 'JSON'
+
+    with h5py.File(file, "a") as f:
+        del f["metadata"]
+        metadata = {"badmetadata": "bad"}
+        jsontowrite = str(metadata).replace("'", '"')
+        f.create_dataset(
+            "metadata", dtype=f"S{len(str(jsontowrite))}", data=str(jsontowrite)
+        )
+        f["metadata"].attrs["datatype"] = "JSON"
 
     tbl1, size = store.read("ch1057600/raw", file)
     assert size == 10
@@ -203,7 +210,7 @@ def test_lh5meta(lgnd_test_data, tmptestdir):
     assert size == 10
     assert tbl1 == tbl2
 
-    with h5py.File(file2, 'a') as f:
+    with h5py.File(file2, "a") as f:
         if "metadata" in f:
             del f["metadata"]
         assert "metadata" not in f

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import h5py
 
 from lgdo import cli, lh5, types
 
@@ -32,6 +33,7 @@ def test_lh5concat(lgnd_test_data, tmptestdir):
         "ch1084803",
         "ch1084804",
         "ch1121600",
+        "metadata",
     ]
     assert lh5.ls(outfile, "ch1057600/raw/") == [
         "ch1057600/raw/abs_delta_mu_usec",
@@ -103,6 +105,7 @@ def test_lh5concat(lgnd_test_data, tmptestdir):
     cli.lh5concat(arg_list)
     assert lh5.ls(outfile) == [
         "ch1057600",
+        "metadata",
     ]
 
     arg_list[5] = "ch1057600/raw/waveform/values"
@@ -125,6 +128,7 @@ def test_lh5concat(lgnd_test_data, tmptestdir):
         "ch1084803",
         "ch1084804",
         "ch1121600",
+        "metadata",
     ]
     assert lh5.ls(outfile, "ch1059201/raw/waveform/") == [
         "ch1059201/raw/waveform/dt",
@@ -149,3 +153,21 @@ def test_lh5concat(lgnd_test_data, tmptestdir):
         assert tbl.packet_id[i] == tbl2.packet_id[i - 10]
         assert np.array_equal(tbl.tracelist[i], tbl2.tracelist[i - 10])
         assert np.array_equal(tbl.waveform.values[i], tbl2.waveform.values[i - 10])
+
+# def test_lh5meta(lgnd_test_data, tmptestdir):
+#     file = lgnd_test_data.get_path(
+#         "lh5/prod-ref-l200/generated/tier/raw/phy/p03/r001/l200-p03-r001-phy-20230322T160139Z-tier_raw.lh5"
+#     )
+#     cli.lh5meta([file])
+
+#     assert lh5.ls(file) == [
+#         "ch1057600",
+#         "ch1059201",
+#         "ch1062405",
+#         "ch1084803",
+#         "ch1084804",
+#         "ch1121600",
+#         "metadata",
+#     ]
+
+#     print('hiiii')


### PR DESCRIPTION
(This pull request can wait til after Nu24, but I wanted to get it in so it can be discussed.)

This pull request adds a specialized way to store attributes of datasets so as to reduce their loading time and reduce the overall loading time of datasets. It is backwards compatible and a command line utility (`lh5meta`) is provided to add this specialized storage to existing files.

As was shown in #78 (see also [this LEGEND internal Confluence page](https://legend-exp.atlassian.net/wiki/spaces/LEGEND/pages/991953524/Investigation+of+LH5+File+Structure+and+I+O)), loading of attributes takes an extremely long time relative to their size and the sizes of our typical datasets. Because the `datatype` of each dataset is required to interpret the dataset, this requires that the attributes of every dataset are read. For a typical `phy` `hit` file, loading of attributes takes the same amount of time as loading of data.

Instead, we can store the attributes in a JSON string that defines a dictionary following the same structure as the LH5 file. This `metadata` string is then stored as its own HDF5 dataset at the top level of the file, as shown below. When `LH5Store` reads in this file, it looks for this `metadata` dataset, converts it to a `dict`, and uses this to define the attributes of the datasets in the file, instead of getting the attributes for each dataset separately. When the user wants to read more than ~10 datasets from a file (e.g. 10 columns of 1 channel or 1 column of 10 channels), this speeds up data loading by up to x2. There is a fixed cost time penalty for interpreting the JSON string such that loading only 1 dataset from the file takes about 4x longer, but the user has the option to not use the metadata and instead load the attributes as usual.

Here are the results of two tests using this script ([test_metadata.py.txt](https://github.com/legend-exp/legend-pydataobj/files/15479275/test_metadata.py.txt)).

1. on my laptop's SSD
```
time to read 1 ch, 1 column: 0.0022 +- 0.00037
time to read 1 ch, 1 column w/ metadata: 0.0093 +- 0.012
time to read 1 ch: 0.034 +- 0.002
time to read 1 ch w/ metadata: 0.023 +- 0.011
time to read 90 ch, 1 column: 0.12 +- 0.0014
time to read 90 ch, 1 column w/ metadata: 0.079 +- 0.0019
time to read 90 ch: 2.9 +- 0.045
time to read 90 ch w/ metadata: 1.5 +- 0.12
```
2. on NERSC CFS for a `phy` `hit` file
```
time to read 1 ch, 1 column: 0.0013 +- 0.0003
time to read 1 ch, 1 column w/ metadata: 0.0032 +- 0.0005
time to read 1 ch: 0.036 +- 0.0016
time to read 1 ch w/ metadata: 0.024 +- 0.014
time to read 90 ch, 1 column: 0.12 +- 0.0038
time to read 90 ch, 1 column w/ metadata: 0.071 +- 0.0021
time to read 90 ch: 3.3 +- 0.041
time to read 90 ch w/ metadata: 1.6 +- 0.031
```
This is the structure of an LH5 file with the `metadata` dataset. The `datatype` is listed as `JSON`.
```
/
|
...
├── ch1121605 · HDF5 group 
│   └── hit · table{timestamp,tp_0_est,dt_eff,is_saturated,cuspEmax_ctc_cal,is_valid_rt_old,is_valid_t0_old,is_valid_tmax_old,is_valid_dteff_old,is_valid_ediff,is_valid_efrac,is_valid_neg_current,is_valid_0vbb_old,is_negative_crosstalk_old,is_discharge,is_neg_energy,is_negative,is_valid_baseline,is_valid_tail,is_downgoing_baseline,is_upgoing_baseline,is_noise_burst,is_valid_bl_slope,is_valid_bl_slope_rms,is_valid_bl_std,is_valid_wf_slope,is_valid_wf_slope_rms,is_valid_wf_std,is_valid_wf_max,is_valid_trapTmax,is_valid_trapTmax_invert,is_valid_pz_std,is_valid_pz_bl_ratio,is_valid_rt,is_valid_t0,is_valid_tmax,is_valid_dteff,is_negative_crosstalk,is_valid_cal,zacEmax_ctc_cal,trapEmax_ctc_cal,AoE_Corrected,AoE_Classifier,AoE_Low_Cut,AoE_Double_Sided_Cut,LQ_Classifier,LQ_Cut,daqenergy_cal,is_baseline,is_physical} 
│       ├── AoE_Classifier · array<1>{real} 
│       |       dtype=float64, shape=(3012,), nbytes=23.5 kB, numchunks=2, chunkshape=(1506,), filters=(shuffle,deflate,)
...       ...
│       └── zacEmax_ctc_cal · array<1>{real} 
│               dtype=float64, shape=(3012,), nbytes=23.5 kB, numchunks=2, chunkshape=(1506,), filters=(shuffle,deflate,)
└── metadata · JSON 
        dtype=|S408032, shape=(), nbytes=398.5 kB, numchunks=contiguous, filters=None
```
Some details of implementation:

- `LH5Store` now has a metadata cache that contains the `metadata` and modification timestamp of a file that is read. This allows for e.g. reading one channel at a time from a file and paying the `metadata` conversion penalty only once. The modification timestamp is compared to see whether the file has been modified since it was last read and the `metadata` will be read again if so. 
- The default metadata cache size is set to 100 MB (about 30 `hit` files, 3 MB each in memory), but this can be changed by the user at the time of `LH5Store` instantiation or later with the `LH5Store.metacachesize` attribute. The `LH5Store.clear_metadata_cache(force=True)` method can be used to forcibly clear the cache.
- When the user writes data to an LH5 file, the user should do `LH5Store.write_metadata()` once they are finished writing other data to the file. The `metadata` dataset is not updated on-the-fly because this would increase the time it takes to write data very significantly if the attributes need to be trawled over every time a dataset is written. It is also very likely that the `metadata` could be incorrectly written if we attempted to keep track of the attributes of every column during reading and writing since the user can perform `h5py` file operations outside of the scope of `lgdo` and the `metadata` would not be appropriately updated. Instead, the user should just write the `metadata` once they are finished with file operations using `LH5Store.write_metadata()` or the command line utility `lh5meta`.
- If some requested dataset is not found or some attribute is not found in the `metadata`, the LH5 file attributes are instead checked. Probably not every pathological case is handled correctly, but the user can just rewrite the `metadata` for the file to fix the issue. This makes the pull request backwards compatible as well, so users who do not use the `metadata` should not notice any difference.
- The user may ignore the `metadata` dataset with the `use_metadata` flag for the `LH5Store` methods `read` and `read_n_rows`. This will improve reading speed if only a few (~<10) datasets are being read from a file compared to reading in the whole `metadata`.
- New unit tests are added.