### PR TITLE
Replace file/name with hdf5 group/dataset when decoding

### DIFF
--- a/src/lgdo/lh5/_serializers/read/array.py
+++ b/src/lgdo/lh5/_serializers/read/array.py
@@ -9,26 +9,26 @@ from .ndarray import _h5_read_ndarray
 log = logging.getLogger(__name__)
 
 
-def _h5_read_array_generic(type_, name, h5f, **kwargs):
-    nda, attrs, n_rows_to_read = _h5_read_ndarray(name, h5f, **kwargs)
+def _h5_read_array_generic(type_, h5d, **kwargs):
+    nda, attrs, n_rows_to_read = _h5_read_ndarray(h5d, **kwargs)
 
     obj_buf = kwargs["obj_buf"]
 
     if obj_buf is None:
         return type_(nda=nda, attrs=attrs), n_rows_to_read
 
-    utils.check_obj_buf_attrs(obj_buf.attrs, attrs, h5f, name)
+    utils.check_obj_buf_attrs(obj_buf.attrs, attrs, h5d)
 
     return obj_buf, n_rows_to_read
 
 
-def _h5_read_array(name, h5f, **kwargs):
-    return _h5_read_array_generic(Array, name, h5f, **kwargs)
+def _h5_read_array(h5d, **kwargs):
+    return _h5_read_array_generic(Array, h5d, **kwargs)
 
 
-def _h5_read_fixedsize_array(name, h5f, **kwargs):
-    return _h5_read_array_generic(FixedSizeArray, name, h5f, **kwargs)
+def _h5_read_fixedsize_array(h5d, **kwargs):
+    return _h5_read_array_generic(FixedSizeArray, h5d, **kwargs)
 
 
-def _h5_read_array_of_equalsized_arrays(name, h5f, **kwargs):
-    return _h5_read_array_generic(ArrayOfEqualSizedArrays, name, h5f, **kwargs)
+def _h5_read_array_of_equalsized_arrays(h5d, **kwargs):
+    return _h5_read_array_generic(ArrayOfEqualSizedArrays, h5d, **kwargs)

--- a/src/lgdo/lh5/_serializers/read/scalar.py
+++ b/src/lgdo/lh5/_serializers/read/scalar.py
@@ -15,7 +15,7 @@ def _h5_read_scalar(
     obj_buf=None,
 ):
     value = h5d[()]
-    attrs=dict(h5d.attrs)
+    attrs = dict(h5d.attrs)
 
     # special handling for bools
     # (c and Julia store as uint8 so cast to bool)

--- a/src/lgdo/lh5/_serializers/read/scalar.py
+++ b/src/lgdo/lh5/_serializers/read/scalar.py
@@ -11,24 +11,24 @@ log = logging.getLogger(__name__)
 
 
 def _h5_read_scalar(
-    name,
-    h5f,
+    h5d,
     obj_buf=None,
 ):
-    value = h5f[name][()]
+    value = h5d[()]
+    attrs=dict(h5d.attrs)
 
     # special handling for bools
     # (c and Julia store as uint8 so cast to bool)
-    if h5f[name].attrs["datatype"] == "bool":
+    if attrs["datatype"] == "bool":
         value = np.bool_(value)
 
     if obj_buf is not None:
         if not isinstance(obj_buf, Scalar):
             msg = "object buffer a Scalar"
-            raise LH5DecodeError(msg, h5f, name)
+            raise LH5DecodeError(msg, h5d)
 
         obj_buf.value = value
-        obj_buf.attrs.update(h5f[name].attrs)
+        obj_buf.attrs.update(attrs)
         return obj_buf, 1
 
-    return Scalar(value=value, attrs=h5f[name].attrs), 1
+    return Scalar(value=value, attrs=attrs), 1

--- a/src/lgdo/lh5/_serializers/read/utils.py
+++ b/src/lgdo/lh5/_serializers/read/utils.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from ...exceptions import LH5DecodeError
 
 
-def check_obj_buf_attrs(attrs, new_attrs, file, name):
+def check_obj_buf_attrs(attrs, new_attrs, obj):
     if set(attrs.keys()) != set(new_attrs.keys()):
         msg = (
             f"existing buffer and new data chunk have different attributes: "
-            f"obj_buf.attrs={attrs} != {file.filename}[{name}].attrs={new_attrs}"
+            f"obj_buf.attrs={attrs} != {obj.file.filename}[{obj.name}].attrs={new_attrs}"
         )
-        raise LH5DecodeError(msg, file, name)
+        raise LH5DecodeError(msg, obj)

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -118,7 +118,7 @@ def read(
             if isinstance(lh5_file, str):
                 h5f = h5py.File(h5f, mode="r")
             lh5_obj += h5f[name]
-        
+
     obj, n_rows_read = _serializers._h5_read_lgdo(
         lh5_obj,
         start_row=start_row,

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -116,7 +116,7 @@ def read(
         lh5_obj = []
         for h5f in lh5_file:
             if isinstance(lh5_file, str):
-                h5f = h5py.File(h5f, mode="r")
+                h5f = h5py.File(h5f, mode="r")  # noqa: PLW2901
             lh5_obj += h5f[name]
 
     obj, n_rows_read = _serializers._h5_read_lgdo(

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -107,9 +107,20 @@ def read(
         `n_rows_read` will be``1``. For tables it is redundant with
         ``table.loc``. If `obj_buf` is ``None``, only `object` is returned.
     """
+    if isinstance(lh5_file, h5py.File):
+        lh5_obj = lh5_file[name]
+    elif isinstance(lh5_file, str):
+        lh5_file = h5py.File(lh5_file, mode="r")
+        lh5_obj = lh5_file[name]
+    else:
+        lh5_obj = []
+        for h5f in lh5_file:
+            if isinstance(lh5_file, str):
+                h5f = h5py.File(h5f, mode="r")
+            lh5_obj += h5f[name]
+        
     obj, n_rows_read = _serializers._h5_read_lgdo(
-        name,
-        lh5_file,
+        lh5_obj,
         start_row=start_row,
         n_rows=n_rows,
         idx=idx,

--- a/src/lgdo/lh5/exceptions.py
+++ b/src/lgdo/lh5/exceptions.py
@@ -4,11 +4,11 @@ import h5py
 
 
 class LH5DecodeError(Exception):
-    def __init__(self, message: str, file: str, obj: str) -> None:
+    def __init__(self, message: str, obj: h5py.Dataset | h5py.Group) -> None:
         super().__init__(message)
 
-        self.file = file.filename if isinstance(file, h5py.File) else file
-        self.obj = obj
+        self.file = obj.file.filename
+        self.obj = obj.name
 
     def __str__(self) -> str:
         return (

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -144,13 +144,12 @@ class LH5Store:
         """
         # grab files from store
         if not isinstance(lh5_file, (str, h5py.File)):
-            lh5_file = [self.gimme_file(f, "r") for f in list(lh5_file)]
+            lh5_obj = [self.gimme_file(f, "r")[name] for f in list(lh5_file)]
         else:
-            lh5_file = self.gimme_file(lh5_file, "r")
+            lh5_obj = self.gimme_file(lh5_file, "r")[name]
 
         return _serializers._h5_read_lgdo(
-            name,
-            lh5_file,
+            lh5_obj,
             start_row=start_row,
             n_rows=n_rows,
             idx=idx,

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -29,7 +29,7 @@ def get_buffer(
     Sets size to `size` if object has a size.
     """
     obj, n_rows = _serializers._h5_read_lgdo(
-        name, lh5_file, n_rows=0, field_mask=field_mask
+        lh5_file[name], n_rows=0, field_mask=field_mask
     )
 
     if hasattr(obj, "resize") and size is not None:


### PR DESCRIPTION
When calling read, the recursive functions will now pass the current group/dataset rather than a file/name pair. The file/name pair required re-looking up objects, which is quite slow because it involves re-parsing the hdf5 metadata.