### PR TITLE
I/O performance improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "awkward>=2",
     "awkward-pandas",
     "colorlog",
-    "h5py>=3.2",
+    "h5py>=3.10",
     "hdf5plugin",
     "numba!=0.53.*,!=0.54.*",
     "numexpr",

--- a/src/lgdo/lh5/_serializers/read/array.py
+++ b/src/lgdo/lh5/_serializers/read/array.py
@@ -9,26 +9,26 @@ from .ndarray import _h5_read_ndarray
 log = logging.getLogger(__name__)
 
 
-def _h5_read_array_generic(type_, name, h5f, **kwargs):
-    nda, attrs, n_rows_to_read = _h5_read_ndarray(name, h5f, **kwargs)
+def _h5_read_array_generic(type_, h5d, **kwargs):
+    nda, attrs, n_rows_to_read = _h5_read_ndarray(h5d, **kwargs)
 
     obj_buf = kwargs["obj_buf"]
 
     if obj_buf is None:
         return type_(nda=nda, attrs=attrs), n_rows_to_read
 
-    utils.check_obj_buf_attrs(obj_buf.attrs, attrs, h5f, name)
+    utils.check_obj_buf_attrs(obj_buf.attrs, attrs, h5d)
 
     return obj_buf, n_rows_to_read
 
 
-def _h5_read_array(name, h5f, **kwargs):
-    return _h5_read_array_generic(Array, name, h5f, **kwargs)
+def _h5_read_array(h5d, **kwargs):
+    return _h5_read_array_generic(Array, h5d, **kwargs)
 
 
-def _h5_read_fixedsize_array(name, h5f, **kwargs):
-    return _h5_read_array_generic(FixedSizeArray, name, h5f, **kwargs)
+def _h5_read_fixedsize_array(h5d, **kwargs):
+    return _h5_read_array_generic(FixedSizeArray, h5d, **kwargs)
 
 
-def _h5_read_array_of_equalsized_arrays(name, h5f, **kwargs):
-    return _h5_read_array_generic(ArrayOfEqualSizedArrays, name, h5f, **kwargs)
+def _h5_read_array_of_equalsized_arrays(h5d, **kwargs):
+    return _h5_read_array_generic(ArrayOfEqualSizedArrays, h5d, **kwargs)

--- a/src/lgdo/lh5/_serializers/read/array.py
+++ b/src/lgdo/lh5/_serializers/read/array.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import logging
-import h5py
 
-from .utils import read_attrs
 from ....types import Array, ArrayOfEqualSizedArrays, FixedSizeArray
 from . import utils
 from .ndarray import _h5_read_ndarray

--- a/src/lgdo/lh5/_serializers/read/array.py
+++ b/src/lgdo/lh5/_serializers/read/array.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import logging
+import h5py
 
+from .utils import read_attrs
 from ....types import Array, ArrayOfEqualSizedArrays, FixedSizeArray
 from . import utils
 from .ndarray import _h5_read_ndarray
@@ -9,26 +11,26 @@ from .ndarray import _h5_read_ndarray
 log = logging.getLogger(__name__)
 
 
-def _h5_read_array_generic(type_, h5d, **kwargs):
-    nda, attrs, n_rows_to_read = _h5_read_ndarray(h5d, **kwargs)
+def _h5_read_array_generic(type_, h5d, fname, oname, **kwargs):
+    nda, attrs, n_rows_to_read = _h5_read_ndarray(h5d, fname, oname, **kwargs)
 
     obj_buf = kwargs["obj_buf"]
 
     if obj_buf is None:
         return type_(nda=nda, attrs=attrs), n_rows_to_read
 
-    utils.check_obj_buf_attrs(obj_buf.attrs, attrs, h5d)
+    utils.check_obj_buf_attrs(obj_buf.attrs, attrs, fname, oname)
 
     return obj_buf, n_rows_to_read
 
 
-def _h5_read_array(h5d, **kwargs):
-    return _h5_read_array_generic(Array, h5d, **kwargs)
+def _h5_read_array(h5d, fname, oname, **kwargs):
+    return _h5_read_array_generic(Array, h5d, fname, oname, **kwargs)
 
 
-def _h5_read_fixedsize_array(h5d, **kwargs):
-    return _h5_read_array_generic(FixedSizeArray, h5d, **kwargs)
+def _h5_read_fixedsize_array(h5d, fname, oname, **kwargs):
+    return _h5_read_array_generic(FixedSizeArray, h5d, fname, oname, **kwargs)
 
 
-def _h5_read_array_of_equalsized_arrays(h5d, **kwargs):
-    return _h5_read_array_generic(ArrayOfEqualSizedArrays, h5d, **kwargs)
+def _h5_read_array_of_equalsized_arrays(h5d, fname, oname, **kwargs):
+    return _h5_read_array_generic(ArrayOfEqualSizedArrays, h5d, fname, oname, **kwargs)

--- a/src/lgdo/lh5/_serializers/read/composite.py
+++ b/src/lgdo/lh5/_serializers/read/composite.py
@@ -22,7 +22,6 @@ from ....types import (
 )
 from ... import datatype as dtypeutils
 from ...exceptions import LH5DecodeError
-from ...utils import read_n_rows
 from . import utils
 from .array import (
     _h5_read_array,
@@ -265,7 +264,7 @@ def _h5_read_struct(
 def _h5_read_table(
     h5g,
     fname,
-    oname,    
+    oname,
     start_row=0,
     n_rows=sys.maxsize,
     idx=None,

--- a/src/lgdo/lh5/_serializers/read/composite.py
+++ b/src/lgdo/lh5/_serializers/read/composite.py
@@ -131,6 +131,8 @@ def _h5_read_lgdo(
     if lgdotype is Histogram:
         return _h5_read_histogram(
             h5o,
+            fname,
+            oname,
             start_row=start_row,
             n_rows=n_rows,
             idx=idx,
@@ -386,6 +388,8 @@ def _h5_read_table(
 
 def _h5_read_histogram(
     h5g,
+    fname,
+    oname,
     start_row=0,
     n_rows=sys.maxsize,
     idx=None,
@@ -397,17 +401,20 @@ def _h5_read_histogram(
 ):
     if obj_buf is not None or obj_buf_start != 0:
         msg = "reading a histogram into an existing object buffer is not supported"
-        raise LH5DecodeError(msg, h5g)
+        raise LH5DecodeError(msg, fname, oname)
 
     struct, n_rows_read = _h5_read_struct(
         h5g,
-        start_row,
-        n_rows,
-        idx,
-        use_h5idx,
-        field_mask,
-        decompress,
+        fname,
+        oname,
+        start_row=start_row,
+        n_rows=n_rows,
+        idx=idx,
+        use_h5idx=use_h5idx,
+        field_mask=field_mask,
+        decompress=decompress,
     )
+
     binning = []
     for _, a in struct.binning.items():
         be = a.binedges
@@ -417,7 +424,7 @@ def _h5_read_histogram(
             b = (be, None, None, None, a.closedleft.value)
         else:
             msg = "unexpected binning of histogram"
-            raise LH5DecodeError(msg, h5g)
+            raise LH5DecodeError(msg, fname, oname)
         ax = Histogram.Axis(*b)
         # copy attrs to "clone" the "whole" struct.
         ax.attrs = a.getattrs(datatype=True)

--- a/src/lgdo/lh5/_serializers/read/composite.py
+++ b/src/lgdo/lh5/_serializers/read/composite.py
@@ -80,7 +80,7 @@ def _h5_read_lgdo(
         if len(field_mask) > 0:
             default = not field_mask[next(iter(field_mask.keys()))]
         field_mask = defaultdict(lambda: default, field_mask)
-    elif isinstance(field_mask, (list, tuple)):
+    elif isinstance(field_mask, (list, tuple, set)):
         field_mask = defaultdict(bool, {field: True for field in field_mask})
     elif not isinstance(field_mask, defaultdict):
         msg = "bad field_mask type"

--- a/src/lgdo/lh5/_serializers/read/encoded.py
+++ b/src/lgdo/lh5/_serializers/read/encoded.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import logging
 import sys
+
 import h5py
 
-from .utils import read_attrs
 from .... import compression as compress
 from ....types import (
     ArrayOfEncodedEqualSizedArrays,
@@ -15,6 +15,7 @@ from .array import (
     _h5_read_array,
 )
 from .scalar import _h5_read_scalar
+from .utils import read_attrs
 from .vector_of_vectors import _h5_read_vector_of_vectors
 
 log = logging.getLogger(__name__)
@@ -26,7 +27,9 @@ def _h5_read_array_of_encoded_equalsized_arrays(
     oname,
     **kwargs,
 ):
-    return _h5_read_encoded_array(ArrayOfEncodedEqualSizedArrays, h5g, fname, oname, **kwargs)
+    return _h5_read_encoded_array(
+        ArrayOfEncodedEqualSizedArrays, h5g, fname, oname, **kwargs
+    )
 
 
 def _h5_read_vector_of_encoded_vectors(

--- a/src/lgdo/lh5/_serializers/read/encoded.py
+++ b/src/lgdo/lh5/_serializers/read/encoded.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import logging
 import sys
+import h5py
 
+from .utils import read_attrs
 from .... import compression as compress
 from ....types import (
     ArrayOfEncodedEqualSizedArrays,
@@ -20,21 +22,27 @@ log = logging.getLogger(__name__)
 
 def _h5_read_array_of_encoded_equalsized_arrays(
     h5g,
+    fname,
+    oname,
     **kwargs,
 ):
-    return _h5_read_encoded_array(ArrayOfEncodedEqualSizedArrays, h5g, **kwargs)
+    return _h5_read_encoded_array(ArrayOfEncodedEqualSizedArrays, h5g, fname, oname, **kwargs)
 
 
 def _h5_read_vector_of_encoded_vectors(
     h5g,
+    fname,
+    oname,
     **kwargs,
 ):
-    return _h5_read_encoded_array(VectorOfEncodedVectors, h5g, **kwargs)
+    return _h5_read_encoded_array(VectorOfEncodedVectors, h5g, fname, oname, **kwargs)
 
 
 def _h5_read_encoded_array(
     lgdotype,
     h5g,
+    fname,
+    oname,
     start_row=0,
     n_rows=sys.maxsize,
     idx=None,
@@ -45,11 +53,11 @@ def _h5_read_encoded_array(
 ):
     if lgdotype not in (ArrayOfEncodedEqualSizedArrays, VectorOfEncodedVectors):
         msg = f"unsupported read of encoded type {lgdotype.__name__}"
-        raise LH5DecodeError(msg, h5g)
+        raise LH5DecodeError(msg, fname, oname)
 
     if not decompress and obj_buf is not None and not isinstance(obj_buf, lgdotype):
         msg = f"object buffer is not a {lgdotype.__name__}"
-        raise LH5DecodeError(msg, h5g)
+        raise LH5DecodeError(msg, fname, oname)
 
     # read out decoded_size, either a Scalar or an Array
     decoded_size_buf = encoded_data_buf = None
@@ -58,8 +66,11 @@ def _h5_read_encoded_array(
         encoded_data_buf = obj_buf.encoded_data
 
     if lgdotype is VectorOfEncodedVectors:
+        h5o = h5py.h5o.open(h5g, b"decoded_size")
         decoded_size, _ = _h5_read_array(
-            h5g["decoded_size"],
+            h5o,
+            fname,
+            f"{oname}/decoded_size",
             start_row=start_row,
             n_rows=n_rows,
             idx=idx,
@@ -67,16 +78,23 @@ def _h5_read_encoded_array(
             obj_buf=None if decompress else decoded_size_buf,
             obj_buf_start=0 if decompress else obj_buf_start,
         )
-
+        h5o.close()
     else:
+        h5o = h5py.h5o.open(h5g, b"decoded_size")
         decoded_size, _ = _h5_read_scalar(
-            h5g["decoded_size"],
+            h5o,
+            fname,
+            f"{oname}/decoded_size",
             obj_buf=None if decompress else decoded_size_buf,
         )
+        h5o.close()
 
     # read out encoded_data, a VectorOfVectors
+    h5o = h5py.h5o.open(h5g, b"encoded_data")
     encoded_data, n_rows_read = _h5_read_vector_of_vectors(
-        h5g["encoded_data"],
+        h5o,
+        fname,
+        f"{oname}/encoded_data",
         start_row=start_row,
         n_rows=n_rows,
         idx=idx,
@@ -84,6 +102,7 @@ def _h5_read_encoded_array(
         obj_buf=None if decompress else encoded_data_buf,
         obj_buf_start=0 if decompress else obj_buf_start,
     )
+    h5o.close()
 
     # return the still encoded data in the buffer object, if there
     if obj_buf is not None and not decompress:
@@ -93,7 +112,7 @@ def _h5_read_encoded_array(
     rawdata = lgdotype(
         encoded_data=encoded_data,
         decoded_size=decoded_size,
-        attrs=dict(h5g.attrs),
+        attrs=read_attrs(h5g, fname, oname),
     )
 
     # already return if no decompression is requested

--- a/src/lgdo/lh5/_serializers/read/ndarray.py
+++ b/src/lgdo/lh5/_serializers/read/ndarray.py
@@ -4,13 +4,13 @@ import logging
 import sys
 from bisect import bisect_left
 
-import numpy as np
 import h5py
+import numpy as np
 
-from .utils import read_attrs
 from ....types import Array
 from ... import datatype
 from ...exceptions import LH5DecodeError
+from .utils import read_attrs
 
 log = logging.getLogger(__name__)
 
@@ -54,12 +54,23 @@ def _h5_read_ndarray(
         n_rows_to_read = n_rows
 
     if idx is None:
-        fspace.select_hyperslab((start_row,) + (0,)*(h5d.rank-1), (1,)*h5d.rank, None, (n_rows_to_read,) + fspace.shape[1:])
+        fspace.select_hyperslab(
+            (start_row,) + (0,) * (h5d.rank - 1),
+            (1,) * h5d.rank,
+            None,
+            (n_rows_to_read,) + fspace.shape[1:],
+        )
     elif use_h5idx:
         # Note that h5s will automatically merge adjacent elements into a range
         fspace.select_none()
         for i in idx:
-            fspace.select_hyperslab((i,) + (0,)*(h5d.rank-1), (1,)*h5d.rank, None, (1,) + fspace.shape[1:], h5py.h5s.SELECT_OR)
+            fspace.select_hyperslab(
+                (i,) + (0,) * (h5d.rank - 1),
+                (1,) * h5d.rank,
+                None,
+                (1,) + fspace.shape[1:],
+                h5py.h5s.SELECT_OR,
+            )
 
     # Now read the array
     if obj_buf is not None and n_rows_to_read > 0:
@@ -70,7 +81,12 @@ def _h5_read_ndarray(
 
         if idx is None or use_h5idx:
             mspace = h5py.h5s.create_simple(obj_buf.nda.shape)
-            mspace.select_hyperslab((obj_buf_start,) + (0,)*(h5d.rank-1), (1,)*h5d.rank, None, (n_rows_to_read,) + fspace.shape[1:])
+            mspace.select_hyperslab(
+                (obj_buf_start,) + (0,) * (h5d.rank - 1),
+                (1,) * h5d.rank,
+                None,
+                (n_rows_to_read,) + fspace.shape[1:],
+            )
             h5d.read(mspace, fspace, obj_buf.nda)
         else:
             tmp = np.empty(fspace.shape, h5d.dtype)

--- a/src/lgdo/lh5/_serializers/read/ndarray.py
+++ b/src/lgdo/lh5/_serializers/read/ndarray.py
@@ -5,7 +5,9 @@ import sys
 from bisect import bisect_left
 
 import numpy as np
+import h5py
 
+from .utils import read_attrs
 from ....types import Array
 from ... import datatype
 from ...exceptions import LH5DecodeError
@@ -15,6 +17,8 @@ log = logging.getLogger(__name__)
 
 def _h5_read_ndarray(
     h5d,
+    fname,
+    oname,
     start_row=0,
     n_rows=sys.maxsize,
     idx=None,
@@ -24,48 +28,38 @@ def _h5_read_ndarray(
 ):
     if obj_buf is not None and not isinstance(obj_buf, Array):
         msg = "object buffer is not an Array"
-        raise LH5DecodeError(msg, h5d)
+        raise LH5DecodeError(msg, fname, oname)
 
     # compute the number of rows to read
     # we culled idx above for start_row and n_rows, now we have to apply
     # the constraint of the length of the dataset
     try:
-        ds_n_rows = h5d.shape[0]
+        fspace = h5d.get_space()
+        ds_n_rows = fspace.shape[0]
     except AttributeError as e:
         msg = "does not seem to be an HDF5 dataset"
-        raise LH5DecodeError(msg, h5d) from e
+        raise LH5DecodeError(msg, fname, oname) from e
 
     if idx is not None:
-        if len(idx[0]) > 0 and idx[0][-1] >= ds_n_rows:
+        if len(idx) > 0 and idx[-1] >= ds_n_rows:
             log.warning("idx indexed past the end of the array in the file. Culling...")
             n_rows_to_read = bisect_left(idx[0], ds_n_rows)
-            idx = (idx[0][:n_rows_to_read],)
-            if len(idx[0]) == 0:
+            idx = (idx[:n_rows_to_read],)
+            if len(idx) == 0:
                 log.warning("idx empty after culling.")
-        n_rows_to_read = len(idx[0])
+        n_rows_to_read = len(idx)
     else:
         n_rows_to_read = ds_n_rows - start_row
     if n_rows_to_read > n_rows:
         n_rows_to_read = n_rows
 
-    # if idx is passed, check if we can make it a slice instead (faster)
-    change_idx_to_slice = False
-
-    # prepare the selection for the read. Use idx if available
-    if idx is not None:
-        # check if idx is empty and convert to slice instead
-        if len(idx[0]) == 0:
-            source_sel = np.s_[0:0]
-            change_idx_to_slice = True
-        # check if idx is contiguous and increasing
-        # if so, convert it to a slice instead (faster)
-        elif np.all(np.diff(idx[0]) == 1):
-            source_sel = np.s_[idx[0][0] : idx[0][-1] + 1]
-            change_idx_to_slice = True
-        else:
-            source_sel = idx
-    else:
-        source_sel = np.s_[start_row : start_row + n_rows_to_read]
+    if idx is None:
+        fspace.select_hyperslab((start_row,) + (0,)*(h5d.rank-1), (1,)*h5d.rank, None, (n_rows_to_read,) + fspace.shape[1:])
+    elif use_h5idx:
+        # Note that h5s will automatically merge adjacent elements into a range
+        fspace.select_none()
+        for i in idx:
+            fspace.select_hyperslab((i,) + (0,)*(h5d.rank-1), (1,)*h5d.rank, None, (1,) + fspace.shape[1:], h5py.h5s.SELECT_OR)
 
     # Now read the array
     if obj_buf is not None and n_rows_to_read > 0:
@@ -74,26 +68,30 @@ def _h5_read_ndarray(
             obj_buf.resize(buf_size)
         dest_sel = np.s_[obj_buf_start:buf_size]
 
-        # this is required to make the read of multiple files faster
-        # until a better solution found.
-        if change_idx_to_slice or idx is None or use_h5idx:
-            h5d.read_direct(obj_buf.nda, source_sel, dest_sel)
+        if idx is None or use_h5idx:
+            mspace = h5py.h5s.create_simple(obj_buf.nda.shape)
+            mspace.select_hyperslab((obj_buf_start,) + (0,)*(h5d.rank-1), (1,)*h5d.rank, None, (n_rows_to_read,) + fspace.shape[1:])
+            h5d.read(mspace, fspace, obj_buf.nda)
         else:
-            # it is faster to read the whole object and then do fancy indexing
-            obj_buf.nda[dest_sel] = h5d[...][source_sel]
-
+            tmp = np.empty(fspace.shape, h5d.dtype)
+            h5d.read(fspace, fspace, tmp)
+            obj_buf.nda[dest_sel, ...] = tmp[idx, ...]
         nda = obj_buf.nda
     elif n_rows == 0:
         tmp_shape = (0,) + h5d.shape[1:]
         nda = np.empty(tmp_shape, h5d.dtype)
-    elif change_idx_to_slice or idx is None or use_h5idx:
-        nda = h5d[source_sel]
     else:
-        # it is faster to read the whole object and then do fancy indexing
-        nda = h5d[...][source_sel]
+        mspace = h5py.h5s.create_simple((n_rows_to_read,) + fspace.shape[1:])
+        nda = np.empty(mspace.shape, h5d.dtype)
+        if idx is None or use_h5idx:
+            h5d.read(mspace, fspace, nda)
+        else:
+            tmp = np.empty(fspace.shape, h5d.dtype)
+            h5d.read(fspace, fspace, tmp)
+            nda[:, ...] = tmp[idx, ...]
 
     # Finally, set attributes and return objects
-    attrs = dict(h5d.attrs)
+    attrs = read_attrs(h5d, fname, oname)
 
     # special handling for bools
     # (c and Julia store as uint8 so cast to bool)

--- a/src/lgdo/lh5/_serializers/read/scalar.py
+++ b/src/lgdo/lh5/_serializers/read/scalar.py
@@ -15,7 +15,7 @@ def _h5_read_scalar(
     obj_buf=None,
 ):
     value = h5d[()]
-    attrs=dict(h5d.attrs)
+    attrs = dict(h5d.attrs)
 
     # special handling for bools
     # (c and Julia store as uint8 so cast to bool)

--- a/src/lgdo/lh5/_serializers/read/scalar.py
+++ b/src/lgdo/lh5/_serializers/read/scalar.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import logging
 
-import numpy as np
 import h5py
+import numpy as np
 
-from .utils import read_attrs
 from ....types import Scalar
 from ...exceptions import LH5DecodeError
+from .utils import read_attrs
 
 log = logging.getLogger(__name__)
 

--- a/src/lgdo/lh5/_serializers/read/scalar.py
+++ b/src/lgdo/lh5/_serializers/read/scalar.py
@@ -11,24 +11,24 @@ log = logging.getLogger(__name__)
 
 
 def _h5_read_scalar(
-    name,
-    h5f,
+    h5d,
     obj_buf=None,
 ):
-    value = h5f[name][()]
+    value = h5d[()]
+    attrs=dict(h5d.attrs)
 
     # special handling for bools
     # (c and Julia store as uint8 so cast to bool)
-    if h5f[name].attrs["datatype"] == "bool":
+    if attrs["datatype"] == "bool":
         value = np.bool_(value)
 
     if obj_buf is not None:
         if not isinstance(obj_buf, Scalar):
             msg = "object buffer a Scalar"
-            raise LH5DecodeError(msg, h5f, name)
+            raise LH5DecodeError(msg, h5d)
 
         obj_buf.value = value
-        obj_buf.attrs.update(h5f[name].attrs)
+        obj_buf.attrs.update(attrs)
         return obj_buf, 1
 
-    return Scalar(value=value, attrs=h5f[name].attrs), 1
+    return Scalar(value=value, attrs=attrs), 1

--- a/src/lgdo/lh5/_serializers/read/utils.py
+++ b/src/lgdo/lh5/_serializers/read/utils.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from ...exceptions import LH5DecodeError
 
 
-def check_obj_buf_attrs(attrs, new_attrs, file, name):
+def check_obj_buf_attrs(attrs, new_attrs, obj):
     if set(attrs.keys()) != set(new_attrs.keys()):
         msg = (
             f"existing buffer and new data chunk have different attributes: "
-            f"obj_buf.attrs={attrs} != {file.filename}[{name}].attrs={new_attrs}"
+            f"obj_buf.attrs={attrs} != {obj.file.filename}[{obj.name}].attrs={new_attrs}"
         )
-        raise LH5DecodeError(msg, file, name)
+        raise LH5DecodeError(msg, obj)

--- a/src/lgdo/lh5/_serializers/read/utils.py
+++ b/src/lgdo/lh5/_serializers/read/utils.py
@@ -1,12 +1,31 @@
 from __future__ import annotations
 
+import h5py
+import numpy as np
+
 from ...exceptions import LH5DecodeError
 
 
-def check_obj_buf_attrs(attrs, new_attrs, obj):
+def check_obj_buf_attrs(attrs, new_attrs, fname, oname):
     if set(attrs.keys()) != set(new_attrs.keys()):
         msg = (
             f"existing buffer and new data chunk have different attributes: "
-            f"obj_buf.attrs={attrs} != {obj.file.filename}[{obj.name}].attrs={new_attrs}"
+            f"obj_buf.attrs={attrs} != {fname}[{oname}].attrs={new_attrs}"
         )
         raise LH5DecodeError(msg, obj)
+
+def read_attrs(h5o, fname, oname):
+    """Read all attributes for an hdf5 dataset or group using low level API
+    and return them as a dict. Assume all are string types."""
+    attrs = {}
+    for i_attr in range(h5py.h5a.get_num_attrs(h5o)):
+        h5a = h5py.h5a.open(h5o, index=i_attr)
+        name = h5a.get_name().decode()
+        val = np.empty((), h5a.dtype)
+        h5a.read(val)
+        if h5a.get_type().get_class() == h5py.h5t.STRING:
+            attrs[name] = val.item().decode()
+        else:
+            attrs[name] = val.item()
+        h5a.close()
+    return attrs

--- a/src/lgdo/lh5/_serializers/read/utils.py
+++ b/src/lgdo/lh5/_serializers/read/utils.py
@@ -12,15 +12,19 @@ def check_obj_buf_attrs(attrs, new_attrs, fname, oname):
             f"existing buffer and new data chunk have different attributes: "
             f"obj_buf.attrs={attrs} != {fname}[{oname}].attrs={new_attrs}"
         )
-        raise LH5DecodeError(msg, obj)
+        raise LH5DecodeError(msg, fname, oname)
+
 
 def read_attrs(h5o, fname, oname):
     """Read all attributes for an hdf5 dataset or group using low level API
-    and return them as a dict. Assume all are string types."""
+    and return them as a dict. Assume all are strings or scalar types."""
     attrs = {}
     for i_attr in range(h5py.h5a.get_num_attrs(h5o)):
         h5a = h5py.h5a.open(h5o, index=i_attr)
         name = h5a.get_name().decode()
+        if h5a.shape != ():
+            msg = f"attribute {name} is not a string or scalar"
+            raise LH5DecodeError(msg, fname, oname)
         val = np.empty((), h5a.dtype)
         h5a.read(val)
         if h5a.get_type().get_class() == h5py.h5t.STRING:

--- a/src/lgdo/lh5/_serializers/read/vector_of_vectors.py
+++ b/src/lgdo/lh5/_serializers/read/vector_of_vectors.py
@@ -5,7 +5,9 @@ import sys
 
 import numba
 import numpy as np
+import h5py
 
+from .utils import read_attrs
 from ....types import (
     Array,
     VectorOfVectors,
@@ -21,6 +23,8 @@ log = logging.getLogger(__name__)
 
 def _h5_read_vector_of_vectors(
     h5g,
+    fname,
+    oname,
     start_row=0,
     n_rows=sys.maxsize,
     idx=None,
@@ -30,12 +34,15 @@ def _h5_read_vector_of_vectors(
 ):
     if obj_buf is not None and not isinstance(obj_buf, VectorOfVectors):
         msg = "object buffer is not a VectorOfVectors"
-        raise LH5DecodeError(msg, h5g)
+        raise LH5DecodeError(msg, fname, oname)
 
     # read out cumulative_length
     cumulen_buf = None if obj_buf is None else obj_buf.cumulative_length
+    h5d_cl = h5py.h5d.open(h5g, b"cumulative_length")
     cumulative_length, n_rows_read = _h5_read_array(
-        h5g["cumulative_length"],
+        h5d_cl,
+        fname,
+        f"{oname}/cumulative_length",
         start_row=start_row,
         n_rows=n_rows,
         idx=idx,
@@ -51,17 +58,19 @@ def _h5_read_vector_of_vectors(
     if idx is not None and n_rows_read > 0:
         # get the starting indices for each array in flattened data:
         # the starting index for array[i] is cumulative_length[i-1]
-        idx2 = (np.asarray(idx[0]).copy() - 1,)
+        idx2 = np.asarray(idx).copy() - 1
 
         # re-read cumulative_length with these indices
         # note this will allocate memory for fd_starts!
         fd_start = None
-        if idx2[0][0] == -1:
-            idx2 = (idx2[0][1:],)
+        if idx2[0] == -1:
+            idx2 = idx2[1:]
             fd_start = 0  # this variable avoids an ndarray append
 
         fd_starts, fds_n_rows_read = _h5_read_array(
-            h5g["cumulative_length"],
+            h5d_cl,
+            fname,
+            f"{oname}/cumulative_length",
             start_row=start_row,
             n_rows=n_rows,
             idx=idx2,
@@ -98,7 +107,11 @@ def _h5_read_vector_of_vectors(
             # need to read out the cumulen sample -before- the first sample
             # read above in order to get the starting row of the first
             # vector to read out in flattened_data
-            fd_start = h5g["cumulative_length"][start_row - 1]
+            fspace = h5d_cl.get_space()
+            fspace.select_elements([start_row-1])
+            mspace = h5py.h5s.create(h5py.h5s.SCALAR)
+            fd_start = np.empty((), h5d_cl.dtype)
+            h5d_cl.read(mspace, fspace, fd_start)
 
             # check limits for values that will be used subsequently
             if this_cumulen_nda[-1] < fd_start:
@@ -112,7 +125,7 @@ def _h5_read_vector_of_vectors(
                     f"cumulative_length non-increasing between entries "
                     f"{start_row} and {start_row+n_rows_read}"
                 )
-                raise LH5DecodeError(msg, h5g)
+                raise LH5DecodeError(msg, fname, oname)
 
         # determine the number of rows for the flattened_data readout
         fd_n_rows = this_cumulen_nda[-1] if n_rows_read > 0 else 0
@@ -125,6 +138,8 @@ def _h5_read_vector_of_vectors(
         # First we need to subtract off the in-file offset for the start of
         # read for flattened_data
         this_cumulen_nda -= fd_start
+
+    h5d_cl.close()
 
     # If we started with a partially-filled buffer, add the
     # appropriate offset for the start of the in-memory flattened
@@ -144,17 +159,23 @@ def _h5_read_vector_of_vectors(
             fd_buf.resize(fdb_size)
 
     # now read
-    lgdotype = dtypeutils.datatype(h5g["flattened_data"].attrs["datatype"])
+    h5o = h5py.h5o.open(h5g, b"flattened_data")
+    h5a_dtype = h5py.h5a.open(h5o, b"datatype")
+    val = np.empty((), 'O')
+    h5a_dtype.read(val)
+    lgdotype = dtypeutils.datatype(val.item().decode())
     if lgdotype is Array:
         _func = _h5_read_array
     elif lgdotype is VectorOfVectors:
         _func = _h5_read_vector_of_vectors
     else:
         msg = "type {lgdotype.__name__} is not supported"
-        raise LH5DecodeError(msg, h5g, "flattened_data")
+        raise LH5DecodeError(msg, fname, f"{oname}/flattened_data")
 
     flattened_data, _ = _func(
-        h5g["flattened_data"],
+        h5o,
+        fname,
+        f"{oname}/flattened_data",
         start_row=fd_start,
         n_rows=fd_n_rows,
         idx=fd_idx,
@@ -162,6 +183,7 @@ def _h5_read_vector_of_vectors(
         obj_buf=fd_buf,
         obj_buf_start=fd_buf_start,
     )
+    h5o.close()
 
     if obj_buf is not None:
         # if the buffer is partially filled, cumulative_length will be invalid
@@ -176,7 +198,7 @@ def _h5_read_vector_of_vectors(
         VectorOfVectors(
             flattened_data=flattened_data,
             cumulative_length=cumulative_length,
-            attrs=dict(h5g.attrs),
+            attrs=read_attrs(h5g, fname, oname),
         ),
         n_rows_read,
     )
@@ -194,4 +216,4 @@ def _make_fd_idx(starts, stops, idx):
         for i in range(starts[j], stops[j]):
             idx[k] = i
             k += 1
-    return (idx,)
+    return idx

--- a/src/lgdo/lh5/_serializers/read/vector_of_vectors.py
+++ b/src/lgdo/lh5/_serializers/read/vector_of_vectors.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import logging
 import sys
 
+import h5py
 import numba
 import numpy as np
-import h5py
 
-from .utils import read_attrs
 from ....types import (
     Array,
     VectorOfVectors,
@@ -17,6 +16,7 @@ from ...exceptions import LH5DecodeError
 from .array import (
     _h5_read_array,
 )
+from .utils import read_attrs
 
 log = logging.getLogger(__name__)
 
@@ -108,7 +108,7 @@ def _h5_read_vector_of_vectors(
             # read above in order to get the starting row of the first
             # vector to read out in flattened_data
             fspace = h5d_cl.get_space()
-            fspace.select_elements([start_row-1])
+            fspace.select_elements([start_row - 1])
             mspace = h5py.h5s.create(h5py.h5s.SCALAR)
             fd_start = np.empty((), h5d_cl.dtype)
             h5d_cl.read(mspace, fspace, fd_start)
@@ -161,7 +161,7 @@ def _h5_read_vector_of_vectors(
     # now read
     h5o = h5py.h5o.open(h5g, b"flattened_data")
     h5a_dtype = h5py.h5a.open(h5o, b"datatype")
-    val = np.empty((), 'O')
+    val = np.empty((), "O")
     h5a_dtype.read(val)
     lgdotype = dtypeutils.datatype(val.item().decode())
     if lgdotype is Array:

--- a/src/lgdo/lh5/_serializers/read/vector_of_vectors.py
+++ b/src/lgdo/lh5/_serializers/read/vector_of_vectors.py
@@ -108,7 +108,7 @@ def _h5_read_vector_of_vectors(
             # read above in order to get the starting row of the first
             # vector to read out in flattened_data
             fspace = h5d_cl.get_space()
-            fspace.select_elements([start_row - 1])
+            fspace.select_elements([[start_row - 1]])
             mspace = h5py.h5s.create(h5py.h5s.SCALAR)
             fd_start = np.empty((), h5d_cl.dtype)
             h5d_cl.read(mspace, fspace, fd_start)

--- a/src/lgdo/lh5/_serializers/write/array.py
+++ b/src/lgdo/lh5/_serializers/write/array.py
@@ -71,7 +71,7 @@ def _h5_write_array(
         _attrs = obj.getattrs(datatype=True)
         _attrs.pop("compression", None)
         _attrs.pop("hdf5_settings", None)
-        ds.attrs.update(_attrs)
+        ds.attrs.update( { k:v.encode('utf-8') if isinstance(v, str) else v for k, v in _attrs.items() } )
 
         return
 

--- a/src/lgdo/lh5/_serializers/write/array.py
+++ b/src/lgdo/lh5/_serializers/write/array.py
@@ -71,7 +71,12 @@ def _h5_write_array(
         _attrs = obj.getattrs(datatype=True)
         _attrs.pop("compression", None)
         _attrs.pop("hdf5_settings", None)
-        ds.attrs.update( { k:v.encode('utf-8') if isinstance(v, str) else v for k, v in _attrs.items() } )
+        ds.attrs.update(
+            {
+                k: v.encode("utf-8") if isinstance(v, str) else v
+                for k, v in _attrs.items()
+            }
+        )
 
         return
 

--- a/src/lgdo/lh5/_serializers/write/composite.py
+++ b/src/lgdo/lh5/_serializers/write/composite.py
@@ -51,13 +51,15 @@ def _h5_write_lgdo(
     if not isinstance(lh5_file, h5py.File):
         mode = "w" if wo_mode == "of" or not os.path.exists(lh5_file) else "a"
         if mode == "w":
-            file_kwargs.update({
-                "fs_strategy":"page",
-                "fs_page_size":65536,
-                "fs_persist":True,
-                "fs_threshold":1,
-                "libver":("latest", "latest")
-            })
+            file_kwargs.update(
+                {
+                    "fs_strategy": "page",
+                    "fs_page_size": 65536,
+                    "fs_persist": True,
+                    "fs_threshold": 1,
+                    "libver": ("latest", "latest"),
+                }
+            )
         lh5_file = h5py.File(lh5_file, mode=mode, **file_kwargs)
 
     log.debug(

--- a/src/lgdo/lh5/_serializers/write/composite.py
+++ b/src/lgdo/lh5/_serializers/write/composite.py
@@ -29,8 +29,10 @@ def _h5_write_lgdo(
 ):
     assert isinstance(obj, types.LGDO)
 
-    file_kwargs = { k:h5py_kwargs[k] for k in h5py_kwargs & signature(h5py.File).parameters.keys() }
-    h5py_kwargs = { k:h5py_kwargs[k] for k in h5py_kwargs - file_kwargs.keys() }
+    file_kwargs = {
+        k: h5py_kwargs[k] for k in h5py_kwargs & signature(h5py.File).parameters.keys()
+    }
+    h5py_kwargs = {k: h5py_kwargs[k] for k in h5py_kwargs - file_kwargs.keys()}
     if wo_mode == "write_safe":
         wo_mode = "w"
     if wo_mode == "append":

--- a/src/lgdo/lh5/_serializers/write/scalar.py
+++ b/src/lgdo/lh5/_serializers/write/scalar.py
@@ -20,4 +20,4 @@ def _h5_write_scalar(obj, name, lh5_file, group="/", wo_mode="append"):
             raise LH5EncodeError(msg, lh5_file, group, name)
 
     ds = group.create_dataset(name, shape=(), data=obj.value)
-    ds.attrs.update(obj.attrs)
+    ds.attrs.update( { k:v.encode('utf-8') if isinstance(v, str) else v for k, v in obj.attrs.items() } )

--- a/src/lgdo/lh5/_serializers/write/scalar.py
+++ b/src/lgdo/lh5/_serializers/write/scalar.py
@@ -20,4 +20,9 @@ def _h5_write_scalar(obj, name, lh5_file, group="/", wo_mode="append"):
             raise LH5EncodeError(msg, lh5_file, group, name)
 
     ds = group.create_dataset(name, shape=(), data=obj.value)
-    ds.attrs.update( { k:v.encode('utf-8') if isinstance(v, str) else v for k, v in obj.attrs.items() } )
+    ds.attrs.update(
+        {
+            k: v.encode("utf-8") if isinstance(v, str) else v
+            for k, v in obj.attrs.items()
+        }
+    )

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -26,6 +26,7 @@ def read(
     obj_buf: types.LGDO = None,
     obj_buf_start: int = 0,
     decompress: bool = True,
+    locking: bool = False,
 ) -> types.LGDO | tuple[types.LGDO, int]:
     """Read LH5 object data from a file.
 
@@ -100,6 +101,8 @@ def read(
         Decompress data encoded with LGDO's compression routines right
         after reading. The option has no effect on data encoded with HDF5
         built-in filters, which is always decompressed upstream by HDF5.
+    locking
+        Lock HDF5 file while reading
 
     Returns
     -------
@@ -113,7 +116,7 @@ def read(
     if isinstance(lh5_file, h5py.File):
         lh5_obj = lh5_file[name]
     elif isinstance(lh5_file, str):
-        lh5_file = h5py.File(lh5_file, mode="r", locking=False)
+        lh5_file = h5py.File(lh5_file, mode="r", locking=locking)
         lh5_obj = lh5_file[name]
     else:
         lh5_files = list(lh5_file)

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -162,7 +162,7 @@ def read(
             else:
                 obj_buf = obj_ret
                 n_rows_read_i = len(obj_buf)
-            
+
             n_rows_read += n_rows_read_i
             if n_rows_read >= n_rows or obj_buf is None:
                 return obj_buf, n_rows_read

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -118,6 +118,7 @@ def read(
     else:
         lh5_files = list(lh5_file)
         n_rows_read = 0
+        obj_buf_is_new = False
 
         for i, h5f in enumerate(lh5_files):
             if (
@@ -143,7 +144,7 @@ def read(
                 idx_i = None
             n_rows_i = n_rows - n_rows_read
 
-            obj, n_rows_read_i = read(
+            obj_ret = read(
                 name,
                 h5f,
                 start_row,
@@ -155,13 +156,19 @@ def read(
                 obj_buf_start,
                 decompress,
             )
-
+            if isinstance(obj_ret, tuple):
+                obj_buf, n_rows_read_i = obj_ret
+                obj_buf_is_new = True
+            else:
+                obj_buf = obj_ret
+                n_rows_read_i = len(obj_buf)
+            
             n_rows_read += n_rows_read_i
             if n_rows_read >= n_rows or obj_buf is None:
                 return obj_buf, n_rows_read
             start_row = 0
             obj_buf_start += n_rows_read_i
-        return obj_buf, n_rows_read
+        return obj_buf if obj_buf_is_new else (obj_buf, n_rows_read)
 
     if isinstance(idx, (list, tuple)) and len(idx) > 0 and not np.isscalar(idx[0]):
         idx = idx[0]

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -281,8 +281,8 @@ def write(
         enable paged aggregation with a buffer of this size in bytes
         Only used when creating a new file. Useful when writing a file
         with a large number of small datasets. This is a short-hand for
-        (fs_stragety="page", fs_pagesize=[page_buffer], fs_persist=True,
-        fs_threshold=1)
+        ``(fs_stragety="page", fs_pagesize=[page_buffer], fs_persist=True,
+        fs_threshold=1)``
     **h5py_kwargs
         additional keyword arguments forwarded to
         :meth:`h5py.Group.create_dataset` to specify, for example, an HDF5

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -118,7 +118,7 @@ def read(
             if isinstance(lh5_file, str):
                 h5f = h5py.File(h5f, mode="r")
             lh5_obj += h5f[name]
-        
+
     obj, n_rows_read = _serializers._h5_read_lgdo(
         lh5_obj,
         start_row=start_row,

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -136,13 +136,13 @@ def read(
                 if not (isinstance(idx, tuple) and len(idx) == 1):
                     idx = (idx,)
                 # idx is a long continuous array
-                n_rows_i = read_n_rows(h5f)
+                n_rows_i = read_n_rows(name, h5f)
                 # find the length of the subset of idx that contains indices
                 # that are less than n_rows_i
                 n_rows_to_read_i = bisect.bisect_left(idx[0], n_rows_i)
                 # now split idx into idx_i and the remainder
-                idx_i = idx[0][:n_rows_to_read_i]
-                idx = idx[0][n_rows_to_read_i:] - n_rows_i
+                idx_i = np.array(idx[0])[:n_rows_to_read_i]
+                idx = np.array(idx[0])[n_rows_to_read_i:] - n_rows_i
             else:
                 idx_i = None
             n_rows_i = n_rows - n_rows_read

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -116,7 +116,7 @@ def read(
         lh5_obj = []
         for h5f in lh5_file:
             if isinstance(lh5_file, str):
-                h5f = h5py.File(h5f, mode="r")
+                h5f = h5py.File(h5f, mode="r")  # noqa: PLW2901
             lh5_obj += h5f[name]
 
     obj, n_rows_read = _serializers._h5_read_lgdo(

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -107,9 +107,20 @@ def read(
         `n_rows_read` will be``1``. For tables it is redundant with
         ``table.loc``. If `obj_buf` is ``None``, only `object` is returned.
     """
+    if isinstance(lh5_file, h5py.File):
+        lh5_obj = lh5_file[name]
+    elif isinstance(lh5_file, str):
+        lh5_file = h5py.File(lh5_file, mode="r")
+        lh5_obj = lh5_file[name]
+    else:
+        lh5_obj = []
+        for h5f in lh5_file:
+            if isinstance(lh5_file, str):
+                h5f = h5py.File(h5f, mode="r")
+            lh5_obj += h5f[name]
+        
     obj, n_rows_read = _serializers._h5_read_lgdo(
-        name,
-        lh5_file,
+        lh5_obj,
         start_row=start_row,
         n_rows=n_rows,
         idx=idx,

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -281,8 +281,7 @@ def write(
         enable paged aggregation with a buffer of this size in bytes
         Only used when creating a new file. Useful when writing a file
         with a large number of small datasets. This is a short-hand for
-        ``(fs_stragety="page", fs_pagesize=[page_buffer], fs_persist=True,
-        fs_threshold=1)``
+        ``(fs_stragety="page", fs_pagesize=[page_buffer])``
     **h5py_kwargs
         additional keyword arguments forwarded to
         :meth:`h5py.Group.create_dataset` to specify, for example, an HDF5
@@ -295,8 +294,6 @@ def write(
             {
                 "fs_strategy": "page",
                 "fs_page_size": page_buffer,
-                "fs_persist": True,
-                "fs_threshold": 1,
             }
         )
     return _serializers._h5_write_lgdo(

--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -113,7 +113,7 @@ def read(
     if isinstance(lh5_file, h5py.File):
         lh5_obj = lh5_file[name]
     elif isinstance(lh5_file, str):
-        lh5_file = h5py.File(lh5_file, mode="r")
+        lh5_file = h5py.File(lh5_file, mode="r", locking=False)
         lh5_obj = lh5_file[name]
     else:
         lh5_files = list(lh5_file)

--- a/src/lgdo/lh5/exceptions.py
+++ b/src/lgdo/lh5/exceptions.py
@@ -4,11 +4,11 @@ import h5py
 
 
 class LH5DecodeError(Exception):
-    def __init__(self, message: str, file: str, obj: str) -> None:
+    def __init__(self, message: str, obj: h5py.Dataset | h5py.Group) -> None:
         super().__init__(message)
 
-        self.file = file.filename if isinstance(file, h5py.File) else file
-        self.obj = obj
+        self.file = obj.file.filename
+        self.obj = obj.name
 
     def __str__(self) -> str:
         return (

--- a/src/lgdo/lh5/exceptions.py
+++ b/src/lgdo/lh5/exceptions.py
@@ -4,7 +4,7 @@ import h5py
 
 
 class LH5DecodeError(Exception):
-    def __init__(self, message: str, fname: str, oname:str) -> None:
+    def __init__(self, message: str, fname: str, oname: str) -> None:
         super().__init__(message)
 
         self.file = fname

--- a/src/lgdo/lh5/exceptions.py
+++ b/src/lgdo/lh5/exceptions.py
@@ -4,11 +4,11 @@ import h5py
 
 
 class LH5DecodeError(Exception):
-    def __init__(self, message: str, obj: h5py.Dataset | h5py.Group) -> None:
+    def __init__(self, message: str, fname: str, oname:str) -> None:
         super().__init__(message)
 
-        self.file = obj.file.filename
-        self.obj = obj.name
+        self.file = fname
+        self.obj = oname
 
     def __str__(self) -> str:
         return (

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -144,13 +144,12 @@ class LH5Store:
         """
         # grab files from store
         if not isinstance(lh5_file, (str, h5py.File)):
-            lh5_file = [self.gimme_file(f, "r") for f in list(lh5_file)]
+            lh5_obj = [self.gimme_file(f, "r")[name] for f in list(lh5_file)]
         else:
-            lh5_file = self.gimme_file(lh5_file, "r")
+            lh5_obj = self.gimme_file(lh5_file, "r")[name]
 
         return _serializers._h5_read_lgdo(
-            name,
-            lh5_file,
+            lh5_obj,
             start_row=start_row,
             n_rows=n_rows,
             idx=idx,

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -78,7 +78,7 @@ class LH5Store:
             (fs_stragety="page", fs_pagesize=[page_buffer], fs_persist=True,
             fs_threshold=1)
         file_kwargs
-            Keyword arguments for :ref:`h5py.File <https://docs.h5py.org/en/stable/high/file.html#reference>`
+            Keyword arguments for `h5py.File <https://docs.h5py.org/en/stable/high/file.html#reference>`_
         """
         if isinstance(lh5_file, h5py.File):
             return lh5_file

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -36,7 +36,7 @@ class LH5Store:
     lgdo.waveformtable.WaveformTable
     """
 
-    def __init__(self, base_path: str = "", keep_open: bool = False) -> None:
+    def __init__(self, base_path: str = "", keep_open: bool = False, locking: bool = False) -> None:
         """
         Parameters
         ----------
@@ -45,9 +45,12 @@ class LH5Store:
         keep_open
             whether to keep files open by storing the :mod:`h5py` objects as
             class attributes.
+        locking
+            whether to lock files when reading
         """
         self.base_path = "" if base_path == "" else utils.expand_path(base_path)
         self.keep_open = keep_open
+        self.locking = locking
         self.files = {}
 
     def gimme_file(self, lh5_file: str | h5py.File, mode: str = "r") -> h5py.File:
@@ -66,7 +69,7 @@ class LH5Store:
         file_kwargs = {}
         if mode == "r":
             lh5_file = utils.expand_path(lh5_file, base_path=self.base_path)
-            file_kwargs["locking"] = False
+            file_kwargs["locking"] = self.locking
 
         if lh5_file in self.files:
             return self.files[lh5_file]

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -75,8 +75,8 @@ class LH5Store:
             enable paged aggregation with a buffer of this size in bytes
             Only used when creating a new file. Useful when writing a file
             with a large number of small datasets. This is a short-hand for
-            (fs_stragety="page", fs_pagesize=[page_buffer], fs_persist=True,
-            fs_threshold=1)
+            ``(fs_stragety="page", fs_pagesize=[page_buffer], fs_persist=True,
+            fs_threshold=1)``
         file_kwargs
             Keyword arguments for :class:`h5py.File`
         """

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -198,13 +198,13 @@ class LH5Store:
                     if not (isinstance(idx, tuple) and len(idx) == 1):
                         idx = (idx,)
                     # idx is a long continuous array
-                    n_rows_i = utils.read_n_rows(h5f)
+                    n_rows_i = utils.read_n_rows(name, h5f)
                     # find the length of the subset of idx that contains indices
                     # that are less than n_rows_i
                     n_rows_to_read_i = bisect.bisect_left(idx[0], n_rows_i)
                     # now split idx into idx_i and the remainder
-                    idx_i = idx[0][:n_rows_to_read_i]
-                    idx = idx[0][n_rows_to_read_i:] - n_rows_i
+                    idx_i = np.array(idx[0])[:n_rows_to_read_i]
+                    idx = np.array(idx[0])[n_rows_to_read_i:] - n_rows_i
                 else:
                     idx_i = None
                 n_rows_i = n_rows - n_rows_read

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -78,7 +78,7 @@ class LH5Store:
             (fs_stragety="page", fs_pagesize=[page_buffer], fs_persist=True,
             fs_threshold=1)
         file_kwargs
-            Keyword arguments for `h5py.File <https://docs.h5py.org/en/stable/high/file.html#reference>`_
+            Keyword arguments for :class:`h5py.File`
         """
         if isinstance(lh5_file, h5py.File):
             return lh5_file

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -66,6 +66,7 @@ class LH5Store:
         file_kwargs = {}
         if mode == "r":
             lh5_file = utils.expand_path(lh5_file, base_path=self.base_path)
+            file_kwargs["locking"] = False
 
         if lh5_file in self.files:
             return self.files[lh5_file]

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -290,7 +290,9 @@ class LH5Store:
         return _serializers._h5_write_lgdo(
             obj,
             name,
-            self.gimme_file(lh5_file, mode=mode, **file_kwargs),
+            self.gimme_file(
+                lh5_file, mode=mode, page_buffer=page_buffer, **file_kwargs
+            ),
             group=group,
             start_row=start_row,
             n_rows=n_rows,

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -10,8 +10,8 @@ import logging
 import os
 import sys
 from collections.abc import Mapping, Sequence
-from typing import Any
 from inspect import signature
+from typing import Any
 
 import h5py
 import numpy as np
@@ -56,7 +56,13 @@ class LH5Store:
         self.locking = locking
         self.files = {}
 
-    def gimme_file(self, lh5_file: str | h5py.File, mode: str = "r", page_buffer:int = 0, **file_kwargs) -> h5py.File:
+    def gimme_file(
+        self,
+        lh5_file: str | h5py.File,
+        mode: str = "r",
+        page_buffer: int = 0,
+        **file_kwargs,
+    ) -> h5py.File:
         """Returns a :mod:`h5py` file object from the store or creates a new one.
 
         Parameters
@@ -164,7 +170,7 @@ class LH5Store:
         obj_buf: types.LGDO = None,
         obj_buf_start: int = 0,
         decompress: bool = True,
-        **file_kwargs
+        **file_kwargs,
     ) -> tuple[types.LGDO, int]:
         """Read LH5 object data from a file in the store.
 
@@ -249,7 +255,7 @@ class LH5Store:
         n_rows: int | None = None,
         wo_mode: str = "append",
         write_start: int = 0,
-        page_buffer:int = 0,
+        page_buffer: int = 0,
         **h5py_kwargs,
     ) -> None:
         """Write an LGDO into an LH5 file.
@@ -279,7 +285,10 @@ class LH5Store:
         # write_object:overwrite.
         mode = "w" if wo_mode == "of" else "a"
 
-        file_kwargs = { k:h5py_kwargs[k] for k in h5py_kwargs & signature(h5py.File).parameters.keys() }
+        file_kwargs = {
+            k: h5py_kwargs[k]
+            for k in h5py_kwargs & signature(h5py.File).parameters.keys()
+        }
         if page_buffer:
             file_kwargs.update(
                 {

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -75,8 +75,7 @@ class LH5Store:
             enable paged aggregation with a buffer of this size in bytes
             Only used when creating a new file. Useful when writing a file
             with a large number of small datasets. This is a short-hand for
-            ``(fs_stragety="page", fs_pagesize=[page_buffer], fs_persist=True,
-            fs_threshold=1)``
+            ``(fs_stragety="page", fs_pagesize=[page_buffer])``
         file_kwargs
             Keyword arguments for :class:`h5py.File`
         """
@@ -116,8 +115,6 @@ class LH5Store:
                 {
                     "fs_strategy": "page",
                     "fs_page_size": page_buffer,
-                    "fs_persist": True,
-                    "fs_threshold": 1,
                 }
             )
         h5f = h5py.File(full_path, mode, **file_kwargs)
@@ -289,15 +286,6 @@ class LH5Store:
             k: h5py_kwargs[k]
             for k in h5py_kwargs & signature(h5py.File).parameters.keys()
         }
-        if page_buffer:
-            file_kwargs.update(
-                {
-                    "fs_strategy": "page",
-                    "fs_page_size": page_buffer,
-                    "fs_persist": True,
-                    "fs_threshold": 1,
-                }
-            )
 
         return _serializers._h5_write_lgdo(
             obj,

--- a/src/lgdo/lh5/tools.py
+++ b/src/lgdo/lh5/tools.py
@@ -128,7 +128,7 @@ def show(
 
     # open file
     if isinstance(lh5_file, str):
-        lh5_file = h5py.File(utils.expand_path(lh5_file), "r")
+        lh5_file = h5py.File(utils.expand_path(lh5_file), "r", locking=False)
 
     # go to group
     if lh5_group != "/":

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -125,7 +125,7 @@ def get_h5_group(
         else:
             group = base_group.create_group(group)
             if grp_attrs is not None:
-                group.attrs.update(grp_attrs)
+                group.attrs.update({ k:v.encode('utf-8') if isinstance(v, str) else v for k, v in grp_attrs.items() })
             return group
     if (
         grp_attrs is not None
@@ -141,7 +141,8 @@ def get_h5_group(
         log.debug(f"overwriting {group}.attrs...")
         for key in group.attrs:
             group.attrs.pop(key)
-        group.attrs.update(grp_attrs)
+
+        group.attrs.update({ k:v.encode('utf-8') if isinstance(v, str) else v for k, v in grp_attrs.items() })
 
     return group
 

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -29,7 +29,7 @@ def get_buffer(
     Sets size to `size` if object has a size.
     """
     obj, n_rows = _serializers._h5_read_lgdo(
-        name, lh5_file, n_rows=0, field_mask=field_mask
+        lh5_file[name], n_rows=0, field_mask=field_mask
     )
 
     if hasattr(obj, "resize") and size is not None:

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -125,7 +125,12 @@ def get_h5_group(
         else:
             group = base_group.create_group(group)
             if grp_attrs is not None:
-                group.attrs.update({ k:v.encode('utf-8') if isinstance(v, str) else v for k, v in grp_attrs.items() })
+                group.attrs.update(
+                    {
+                        k: v.encode("utf-8") if isinstance(v, str) else v
+                        for k, v in grp_attrs.items()
+                    }
+                )
             return group
     if (
         grp_attrs is not None
@@ -142,7 +147,12 @@ def get_h5_group(
         for key in group.attrs:
             group.attrs.pop(key)
 
-        group.attrs.update({ k:v.encode('utf-8') if isinstance(v, str) else v for k, v in grp_attrs.items() })
+        group.attrs.update(
+            {
+                k: v.encode("utf-8") if isinstance(v, str) else v
+                for k, v in grp_attrs.items()
+            }
+        )
 
     return group
 

--- a/tests/lh5/test_core.py
+++ b/tests/lh5/test_core.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import numpy as np
+
 import lgdo
 from lgdo import lh5
 
@@ -35,3 +37,10 @@ def test_read_as(lh5_file):
         "/data/struct/table", lh5_file, "pd", start_row=1, with_units=True
     )
     assert obj1.equals(obj2)
+
+
+def test_read_multiple_files(lh5_file):
+    lh5_obj = lh5.read("/data/struct/array", [lh5_file, lh5_file, lh5_file])
+    assert isinstance(lh5_obj, lgdo.Array)
+    assert len(lh5_obj) == 9
+    assert (lh5_obj.nda == np.array([2, 3, 4] * 3)).all()

--- a/tests/lh5/test_core.py
+++ b/tests/lh5/test_core.py
@@ -44,7 +44,9 @@ def test_read_multiple_files(lh5_file):
     assert isinstance(lh5_obj, lgdo.Array)
     assert len(lh5_obj) == 9
     assert (lh5_obj.nda == np.array([2, 3, 4] * 3)).all()
-    
-    lh5_obj = lh5.read("/data/struct/array", [lh5_file, lh5_file, lh5_file], idx=[1, 3, 5, 7])
+
+    lh5_obj = lh5.read(
+        "/data/struct/array", [lh5_file, lh5_file, lh5_file], idx=[1, 3, 5, 7]
+    )
     assert len(lh5_obj) == 4
     assert (lh5_obj.nda == np.array([3, 2, 4, 3])).all()

--- a/tests/lh5/test_core.py
+++ b/tests/lh5/test_core.py
@@ -11,7 +11,7 @@ def test_read(lh5_file):
     assert isinstance(lh5_obj, lgdo.Scalar)
     assert lh5_obj.value == 10
     assert lh5_obj.attrs["sth"] == 1
-
+    
 
 def test_write(tmptestdir):
     struct = lgdo.Struct()

--- a/tests/lh5/test_core.py
+++ b/tests/lh5/test_core.py
@@ -11,7 +11,7 @@ def test_read(lh5_file):
     assert isinstance(lh5_obj, lgdo.Scalar)
     assert lh5_obj.value == 10
     assert lh5_obj.attrs["sth"] == 1
-    
+
 
 def test_write(tmptestdir):
     struct = lgdo.Struct()

--- a/tests/lh5/test_core.py
+++ b/tests/lh5/test_core.py
@@ -44,3 +44,7 @@ def test_read_multiple_files(lh5_file):
     assert isinstance(lh5_obj, lgdo.Array)
     assert len(lh5_obj) == 9
     assert (lh5_obj.nda == np.array([2, 3, 4] * 3)).all()
+    
+    lh5_obj = lh5.read("/data/struct/array", [lh5_file, lh5_file, lh5_file], idx=[1, 3, 5, 7])
+    assert len(lh5_obj) == 4
+    assert (lh5_obj.nda == np.array([3, 2, 4, 3])).all()


### PR DESCRIPTION
- Use low level h5py API to for read. Note that this resulted in moving the handling of lists of files from `_serializers.read.composite` to `store.read` and `core.read`. Only the `_serializers` functions are using the low level API; `read` itself is still using `h5py.File` to open the file get the top level group.
- Require h5py >= 3.10. Not sure why, but there is a noticeable performance improvement starting at this version
- Encode string attributes to utf-8 before writing. This is something that happens implicitly anyway, so I'm not sure why doing this helps, but it does
- Write files using paged aggregation. This is a setting that you use when opening a file to write. Right now I have it hard-coded to use 64 kB pages, which seemed to be optimal in terms of file size and read speed, although this was only tested using a file with many small datasets. Also use latest version of file for writing
Among these changes, the low level API made the biggest difference (a factor of almost 2), while the other two changes combine for an improvement of maybe 1.5 or so. The low level API makes a difference without reprocessing our files, while the other two changes happen at file write time, so will only be noticed after reprocessing