### PR TITLE
Updates to LH5Iterator and LH5Store to read huge number of files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ ignore = [
   "PLR2004",  # Magic value used in comparison
   "ISC001",   # Conflicts with formatter
   "PT011",
+  "RUF013",   # complains if you default to None for an asinine reason
 ]
 isort.required-imports = ["from __future__ import annotations"]
 # Uncomment if using a _compat.typing backport

--- a/src/lgdo/lh5/_serializers/read/ndarray.py
+++ b/src/lgdo/lh5/_serializers/read/ndarray.py
@@ -112,6 +112,6 @@ def _h5_read_ndarray(
     # special handling for bools
     # (c and Julia store as uint8 so cast to bool)
     if datatype.get_nested_datatype_string(attrs["datatype"]) == "bool":
-        nda = nda.astype(np.bool_)
+        nda = nda.astype(np.bool_, copy=False)
 
     return (nda, attrs, n_rows_to_read)

--- a/src/lgdo/lh5/_serializers/read/scalar.py
+++ b/src/lgdo/lh5/_serializers/read/scalar.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ....types import Scalar
 from ...exceptions import LH5DecodeError
-from .utils import read_attrs
+from . import utils
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ def _h5_read_scalar(
     sp = h5py.h5s.create(h5py.h5s.SCALAR)
     h5d.read(sp, sp, value)
     value = value[()]
-    attrs = read_attrs(h5d, fname, oname)
+    attrs = utils.read_attrs(h5d, fname, oname)
 
     # special handling for bools
     # (c and Julia store as uint8 so cast to bool)

--- a/src/lgdo/lh5/_serializers/read/utils.py
+++ b/src/lgdo/lh5/_serializers/read/utils.py
@@ -103,7 +103,7 @@ def read_n_rows(h5o, fname, oname):
     raise LH5DecodeError(msg, fname, oname)
 
 
-def read_size_in_bytes(h5o, fname, oname, field_mask = None):
+def read_size_in_bytes(h5o, fname, oname, field_mask=None):
     """Read number of rows in LH5 object"""
     if not h5py.h5a.exists(h5o, b"datatype"):
         msg = "missing 'datatype' attribute"
@@ -117,7 +117,7 @@ def read_size_in_bytes(h5o, fname, oname, field_mask = None):
 
     # scalars are dim-0 datasets
     if lgdotype in (types.Scalar, types.Array, types.ArrayOfEqualSizedArrays):
-        return int(np.prod(h5o.shape)*h5o.dtype.itemsize)
+        return int(np.prod(h5o.shape) * h5o.dtype.itemsize)
 
     # structs don't have rows
     if lgdotype is types.Struct:
@@ -160,9 +160,9 @@ def read_size_in_bytes(h5o, fname, oname, field_mask = None):
         obj = h5py.h5o.open(h5o, b"encoded_data")
         cl = h5py.h5o.open(obj, b"cumulative_length")
         size *= cl.shape[0]
-        size *= 4 # TODO: UPDATE WHEN CODECS SUPPORT MORE DTYPES
+        size *= 4  # TODO: UPDATE WHEN CODECS SUPPORT MORE DTYPES
         obj.close()
-        
+
         return size
 
     msg = f"don't know how to read size of LGDO {lgdotype.__name__}"

--- a/src/lgdo/lh5/_serializers/read/utils.py
+++ b/src/lgdo/lh5/_serializers/read/utils.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import logging
+
 import h5py
 import numpy as np
 
+from .... import types
+from ... import datatype
 from ...exceptions import LH5DecodeError
+
+log = logging.getLogger(__name__)
 
 
 def check_obj_buf_attrs(attrs, new_attrs, fname, oname):
@@ -23,7 +29,7 @@ def read_attrs(h5o, fname, oname):
         h5a = h5py.h5a.open(h5o, index=i_attr)
         name = h5a.get_name().decode()
         if h5a.shape != ():
-            msg = f"attribute {name} is not a string or scalar"
+            msg = f"attribute {oname} is not a string or scalar"
             raise LH5DecodeError(msg, fname, oname)
         val = np.empty((), h5a.dtype)
         h5a.read(val)
@@ -33,3 +39,58 @@ def read_attrs(h5o, fname, oname):
             attrs[name] = val.item()
         h5a.close()
     return attrs
+
+
+def read_n_rows(h5o, fname, oname):
+    """Read number of rows in LH5 object"""
+    if not h5py.h5a.exists(h5o, b"datatype"):
+        msg = "missing 'datatype' attribute"
+        raise LH5DecodeError(msg, fname, oname)
+
+    h5a = h5py.h5a.open(h5o, b"datatype")
+    type_attr = np.empty((), h5a.dtype)
+    h5a.read(type_attr)
+    type_attr = type_attr.item().decode()
+    lgdotype = datatype.datatype(type_attr)
+
+    # scalars are dim-0 datasets
+    if lgdotype is types.Scalar:
+        return None
+
+    # structs don't have rows
+    if lgdotype is types.Struct:
+        return None
+
+    # tables should have elements with all the same length
+    if lgdotype is types.Table:
+        # read out each of the fields
+        rows_read = None
+        for field in datatype.get_struct_fields(type_attr):
+            n_rows_read = read_n_rows(h5py.h5o.open(h5o, field.encode()), fname, field)
+            if not rows_read:
+                rows_read = n_rows_read
+            elif rows_read != n_rows_read:
+                log.warning(
+                    f"'{field}' field in table '{oname}' has {rows_read} rows, "
+                    f"{n_rows_read} was expected"
+                )
+
+        return rows_read
+
+    # length of vector of vectors is the length of its cumulative_length
+    if lgdotype is types.VectorOfVectors:
+        return read_n_rows(
+            h5py.h5o.open(h5o, b"cumulative_length"), fname, "cumulative_length"
+        )
+
+    # length of vector of encoded vectors is the length of its decoded_size
+    if lgdotype in (types.VectorOfEncodedVectors, types.ArrayOfEncodedEqualSizedArrays):
+        return read_n_rows(h5py.h5o.open(h5o, b"encoded_data"), fname, "encoded_data")
+
+    # return array length (without reading the array!)
+    if issubclass(lgdotype, types.Array):
+        # compute the number of rows to read
+        return h5o.get_space().shape[0]
+
+    msg = f"don't know how to read rows of LGDO {lgdotype.__name__}"
+    raise LH5DecodeError(msg, fname, oname)

--- a/src/lgdo/lh5/_serializers/read/vector_of_vectors.py
+++ b/src/lgdo/lh5/_serializers/read/vector_of_vectors.py
@@ -156,7 +156,7 @@ def _h5_read_vector_of_vectors(
         # grow fd_buf if necessary to hold the data
         fdb_size = fd_buf_start + fd_n_rows
         if len(fd_buf) < fdb_size:
-            fd_buf.resize(fdb_size)
+            fd_buf.nda.resize(fdb_size, refcheck=False)
 
     # now read
     h5o = h5py.h5o.open(h5g, b"flattened_data")

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -6,6 +6,7 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
+from numpy.typing import NDArray
 
 from ..types import Array, Scalar, Struct, VectorOfVectors
 from .store import LH5Store

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -31,6 +31,21 @@ class LH5Iterator(typing.Iterator):
     The ``lh5_obj`` that is read by this class is reused in order to avoid
     reallocation of memory; this means that if you want to hold on to data
     between reads, you will have to copy it somewhere!
+    
+    When defining an LH5Iterator, you must give it a list of files and the
+    hdf5 groups containing the data tables you are reading. You may also
+    provide a field mask, and an entry list or mask, specifying which entries
+    to read from the files. You may also pair it with a friend iterator, which 
+    contains a parallel group of files which will be simultaneously read.
+    In addition to accessing requested data via ``lh5_obj``, several
+    properties exist to tell you where that data came from:
+    
+    - lh5_it.current_local_entries: get the entry numbers relative to the
+      file the data came from
+    - lh5_it.current_global_entries: get the entry number relative to the
+      full dataset
+    - lh5_it.current_files: get the file name corresponding to each entry
+    - lh5_it.current_groups: get the group name corresponding to each entry
 
     This class can also be used either for random access:
 
@@ -323,7 +338,7 @@ class LH5Iterator(typing.Iterator):
     @property
     def current_local_entries(self) -> NDArray[int]:
         """Return list of local file entries in buffer"""
-        cur_entries = np.zeros(len(self.lh5_buffer), dtype="int32")
+        cur_entries = np.zeros(self.n_rows, dtype="int32")
         i_file = np.searchsorted(self.entry_map, self.current_i_entry, "right")
         file_start = self._get_file_cumentries(i_file - 1)
         i_local = self.current_i_entry - file_start
@@ -345,12 +360,39 @@ class LH5Iterator(typing.Iterator):
             i_local = 0
             i += n
 
-        return cur_entries
+        return cur_entries  
+
+    @property
+    def current_global_entries(self) -> NDArray[int]:
+        """Return list of local file entries in buffer"""
+        cur_entries = np.zeros(self.n_rows, dtype="int32")
+        i_file = np.searchsorted(self.entry_map, self.current_i_entry, "right")
+        file_start = self._get_file_cumentries(i_file - 1)
+        i_local = self.current_i_entry - file_start
+        i = 0
+
+        while i < len(cur_entries):
+            # number of entries to read from this file
+            file_end = self._get_file_cumentries(i_file)
+            n = min(file_end - file_start - i_local, len(cur_entries) - i)
+            entries = self.get_file_entrylist(i_file)
+
+            if entries is None:
+                cur_entries[i : i + n] = self._get_file_cumlen(i_file - 1) + np.arange(i_local, i_local + n)
+            else:
+                cur_entries[i : i + n] = self._get_file_cumlen(i_file - 1) + entries[i_local : i_local + n]
+
+            i_file += 1
+            file_start = file_end
+            i_local = 0
+            i += n
+
+        return cur_entries  
 
     @property
     def current_files(self) -> NDArray[str]:
         """Return list of file names for entries in buffer"""
-        cur_files = np.zeros(len(self.lh5_buffer), dtype=object)
+        cur_files = np.zeros(self.n_rows, dtype=object)
         i_file = np.searchsorted(self.entry_map, self.current_i_entry, "right")
         file_start = self._get_file_cumentries(i_file - 1)
         i_local = self.current_i_entry - file_start
@@ -372,7 +414,7 @@ class LH5Iterator(typing.Iterator):
     @property
     def current_groups(self) -> NDArray[str]:
         """Return list of group names for entries in buffer"""
-        cur_groups = np.zeros(len(self.lh5_buffer), dtype=object)
+        cur_groups = np.zeros(self.n_rows, dtype=object)
         i_file = np.searchsorted(self.entry_map, self.current_i_entry, "right")
         file_start = self._get_file_cumentries(i_file - 1)
         i_local = self.current_i_entry - file_start

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -77,7 +77,7 @@ class LH5Iterator(typing.Iterator):
             The friend should have the same length and entry list. A single
             LH5 table containing columns from both iterators will be returned.
         """
-        self.lh5_st = LH5Store(base_path=base_path, keep_open=True)
+        self.lh5_st = LH5Store(base_path=base_path, keep_open=3)
 
         # List of files, with wildcards and env vars expanded
         if isinstance(lh5_files, str):
@@ -183,9 +183,7 @@ class LH5Iterator(typing.Iterator):
             fcl = self.file_map[i_start - 1] if i_start > 0 else 0
 
             for i in range(i_start, i_file + 1):
-                fcl += self.lh5_st.read_n_rows(
-                    self.groups[i], self.lh5_files[i]
-                )
+                fcl += self.lh5_st.read_n_rows(self.groups[i], self.lh5_files[i])
                 self.file_map[i] = fcl
         return fcl
 

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -150,12 +150,16 @@ class LH5Iterator(typing.Iterator):
             f = self.lh5_files[0]
             g = self.groups[0]
             n_rows = self.lh5_st.read_n_rows(g, f)
-            
+
             if isinstance(self.buffer_len, str):
                 self.buffer_len = ureg.Quantity(buffer_len)
             if isinstance(self.buffer_len, ureg.Quantity):
-                self.buffer_len = int(self.buffer_len/(self.lh5_st.read_size_in_bytes(g, f)*ureg.B)*n_rows)
-            
+                self.buffer_len = int(
+                    self.buffer_len
+                    / (self.lh5_st.read_size_in_bytes(g, f) * ureg.B)
+                    * n_rows
+                )
+
             self.lh5_buffer = self.lh5_st.get_buffer(
                 g,
                 f,

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -110,9 +110,9 @@ class LH5Iterator(typing.Iterator):
             raise ValueError(msg)
 
         # Map to last row in each file
-        self.file_map = np.full(len(self.lh5_files), np.iinfo("i").max, "i")
+        self.file_map = np.full(len(self.lh5_files), np.iinfo("q").max, "q")
         # Map to last iterator entry for each file
-        self.entry_map = np.full(len(self.lh5_files), np.iinfo("i").max, "i")
+        self.entry_map = np.full(len(self.lh5_files), np.iinfo("q").max, "q")
         self.buffer_len = buffer_len
 
         if len(self.lh5_files) > 0:
@@ -142,13 +142,13 @@ class LH5Iterator(typing.Iterator):
             entry_list = list(entry_list)
             if isinstance(entry_list[0], int):
                 self.local_entry_list = [None] * len(self.file_map)
-                self.global_entry_list = np.array(entry_list, "i")
+                self.global_entry_list = np.array(entry_list, "q")
                 self.global_entry_list.sort()
 
             else:
                 self.local_entry_list = [[]] * len(self.file_map)
                 for i_file, local_list in enumerate(entry_list):
-                    self.local_entry_list[i_file] = np.array(local_list, "i")
+                    self.local_entry_list[i_file] = np.array(local_list, "q")
                     self.local_entry_list[i_file].sort()
 
         elif entry_mask is not None:
@@ -178,8 +178,8 @@ class LH5Iterator(typing.Iterator):
         fcl = self.file_map[i_file]
 
         # if we haven't already calculated, calculate for all files up to i_file
-        if fcl == np.iinfo("i").max:
-            i_start = np.searchsorted(self.file_map, np.iinfo("i").max)
+        if fcl == np.iinfo("q").max:
+            i_start = np.searchsorted(self.file_map, np.iinfo("q").max)
             fcl = self.file_map[i_start - 1] if i_start > 0 else 0
 
             for i in range(i_start, i_file + 1):
@@ -194,8 +194,8 @@ class LH5Iterator(typing.Iterator):
         n = self.entry_map[i_file]
 
         # if we haven't already calculated, calculate for all files up to i_file
-        if n == np.iinfo("i").max:
-            i_start = np.searchsorted(self.entry_map, np.iinfo("i").max)
+        if n == np.iinfo("q").max:
+            i_start = np.searchsorted(self.entry_map, np.iinfo("q").max)
             n = self.entry_map[i_start - 1] if i_start > 0 else 0
 
             for i in range(i_start, i_file + 1):
@@ -226,14 +226,14 @@ class LH5Iterator(typing.Iterator):
             f_end = self._get_file_cumlen(i_file)
             i_start = self._get_file_cumentries(i_file - 1)
             i_stop = np.searchsorted(self.global_entry_list, f_end, "right")
-            elist = np.array(self.global_entry_list[i_start:i_stop], "i") - f_start
+            elist = np.array(self.global_entry_list[i_start:i_stop], "q") - f_start
             self.local_entry_list[i_file] = elist
         return elist
 
     def get_global_entrylist(self) -> np.ndarray:
         """Get global entry list, constructing it if needed"""
         if self.global_entry_list is None and self.local_entry_list is not None:
-            self.global_entry_list = np.zeros(len(self), "i")
+            self.global_entry_list = np.zeros(len(self), "q")
             for i_file in range(len(self.lh5_files)):
                 i_start = self.get_file_cumentries(i_file - 1)
                 i_stop = self.get_file_cumentries(i_file)
@@ -251,7 +251,7 @@ class LH5Iterator(typing.Iterator):
 
         # if file hasn't been opened yet, search through files
         # sequentially until we find the right one
-        if i_file < len(self.lh5_files) and self.entry_map[i_file] == np.iinfo("i").max:
+        if i_file < len(self.lh5_files) and self.entry_map[i_file] == np.iinfo("q").max:
             while i_file < len(self.lh5_files) and entry >= self._get_file_cumentries(
                 i_file
             ):

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -31,15 +31,15 @@ class LH5Iterator(typing.Iterator):
     The ``lh5_obj`` that is read by this class is reused in order to avoid
     reallocation of memory; this means that if you want to hold on to data
     between reads, you will have to copy it somewhere!
-    
+
     When defining an LH5Iterator, you must give it a list of files and the
     hdf5 groups containing the data tables you are reading. You may also
     provide a field mask, and an entry list or mask, specifying which entries
-    to read from the files. You may also pair it with a friend iterator, which 
+    to read from the files. You may also pair it with a friend iterator, which
     contains a parallel group of files which will be simultaneously read.
     In addition to accessing requested data via ``lh5_obj``, several
     properties exist to tell you where that data came from:
-    
+
     - lh5_it.current_local_entries: get the entry numbers relative to the
       file the data came from
     - lh5_it.current_global_entries: get the entry number relative to the
@@ -363,7 +363,7 @@ class LH5Iterator(typing.Iterator):
             i_local = 0
             i += n
 
-        return cur_entries  
+        return cur_entries
 
     @property
     def current_global_entries(self) -> NDArray[int]:
@@ -381,16 +381,20 @@ class LH5Iterator(typing.Iterator):
             entries = self.get_file_entrylist(i_file)
 
             if entries is None:
-                cur_entries[i : i + n] = self._get_file_cumlen(i_file - 1) + np.arange(i_local, i_local + n)
+                cur_entries[i : i + n] = self._get_file_cumlen(i_file - 1) + np.arange(
+                    i_local, i_local + n
+                )
             else:
-                cur_entries[i : i + n] = self._get_file_cumlen(i_file - 1) + entries[i_local : i_local + n]
+                cur_entries[i : i + n] = (
+                    self._get_file_cumlen(i_file - 1) + entries[i_local : i_local + n]
+                )
 
             i_file += 1
             file_start = file_end
             i_local = 0
             i += n
 
-        return cur_entries  
+        return cur_entries
 
     @property
     def current_files(self) -> NDArray[str]:

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -92,10 +92,10 @@ class LH5Iterator(typing.Iterator):
         elif not isinstance(groups, list):
             msg = "group must be a string or appropriate list"
             raise ValueError(msg)
-        elif all([isinstance(g, str) for g in groups]):
+        elif all(isinstance(g, str) for g in groups):
             groups = [groups] * len(lh5_files)
         elif len(groups) == len(lh5_files) and all(
-            [isinstance(l, (list, set, tuple)) for l in groups]
+            isinstance(gr_list, (list, set, tuple)) for gr_list in groups
         ):
             pass
         else:

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -99,6 +99,7 @@ class LH5Iterator(typing.Iterator):
             a \"friend\" LH5Iterator that will be read in parallel with this.
             The friend should have the same length and entry list. A single
             LH5 table containing columns from both iterators will be returned.
+            Note that buffer_len will be set to the minimum of the two.
         """
         self.lh5_st = LH5Store(base_path=base_path, keep_open=file_cache)
 
@@ -210,6 +211,15 @@ class LH5Iterator(typing.Iterator):
             if not isinstance(friend, typing.Iterator):
                 msg = "Friend must be an Iterator"
                 raise ValueError(msg)
+
+            # set buffer_lens to be equal
+            if self.buffer_len < friend.buffer_len:
+                friend.buffer_len = self.buffer_len
+                friend.lh5_buffer.resize(self.buffer_len)
+            elif self.buffer_len > friend.buffer_len:
+                self.buffer_len = friend.buffer_len
+                self.lh5_buffer.resize(friend.buffer_len)
+
             self.lh5_buffer.join(friend.lh5_buffer)
         self.friend = friend
 

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -203,7 +203,7 @@ class LH5Iterator(typing.Iterator):
                 fcl = self._get_file_cumlen(i)
                 if elist is None:
                     # no entry list provided
-                    n += fcl
+                    n = fcl
                 else:
                     n += len(elist)
                     # check that file entries fall inside of file

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -244,9 +244,9 @@ class LH5Iterator(typing.Iterator):
         if self.global_entry_list is None and self.local_entry_list is not None:
             self.global_entry_list = np.zeros(len(self), "q")
             for i_file in range(len(self.lh5_files)):
-                i_start = self.get_file_cumentries(i_file - 1)
-                i_stop = self.get_file_cumentries(i_file)
-                f_start = self.get_file_cumlen(i_file - 1)
+                i_start = self._get_file_cumentries(i_file - 1)
+                i_stop = self._get_file_cumentries(i_file)
+                f_start = self._get_file_cumlen(i_file - 1)
                 self.global_entry_list[i_start:i_stop] = (
                     self.get_file_entrylist(i_file) + f_start
                 )

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -88,13 +88,15 @@ class LH5Iterator(typing.Iterator):
             raise ValueError(msg)
 
         if isinstance(groups, str):
-            groups = [ [groups] ] * len(lh5_files)
+            groups = [[groups]] * len(lh5_files)
         elif not isinstance(groups, list):
             msg = "group must be a string or appropriate list"
             raise ValueError(msg)
-        elif all([ isinstance(g, str) for g in groups ]):
-            groups = [ groups ] * len(lh5_files)
-        elif len(groups)==len(lh5_files) and all([isinstance(l, (list, set, tuple)) for l in groups]):
+        elif all([isinstance(g, str) for g in groups]):
+            groups = [groups] * len(lh5_files)
+        elif len(groups) == len(lh5_files) and all(
+            [isinstance(l, (list, set, tuple)) for l in groups]
+        ):
             pass
         else:
             msg = "group must be a string or appropriate list"

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -65,6 +65,7 @@ class LH5Iterator(typing.Iterator):
         entry_mask: list[bool] | list[list[bool]] | None = None,
         field_mask: dict[str, bool] | list[str] | tuple[str] | None = None,
         buffer_len: int = 3200,
+        file_cache: int = 10,
         friend: typing.Iterator | None = None,
     ) -> None:
         """
@@ -90,12 +91,14 @@ class LH5Iterator(typing.Iterator):
             more details.
         buffer_len
             number of entries to read at a time while iterating through files.
+        file_cache
+            maximum number of files to keep open at a time
         friend
             a \"friend\" LH5Iterator that will be read in parallel with this.
             The friend should have the same length and entry list. A single
             LH5 table containing columns from both iterators will be returned.
         """
-        self.lh5_st = LH5Store(base_path=base_path, keep_open=3)
+        self.lh5_st = LH5Store(base_path=base_path, keep_open=file_cache)
 
         # List of files, with wildcards and env vars expanded
         if isinstance(lh5_files, str):

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -312,3 +312,9 @@ class LH5Store:
         Return ``None`` if it is a :class:`.Scalar` or a :class:`.Struct`.
         """
         return utils.read_n_rows(name, self.gimme_file(lh5_file, "r"))
+
+    def read_size_in_bytes(self, name: str, lh5_file: str | h5py.File) -> int:
+        """Look up the size (in B) of the object. Will recursively crawl
+        through all objects in a Struct or Table
+        """
+        return utils.read_size_in_bytes(name, self.gimme_file(lh5_file, "r"))

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -314,7 +314,7 @@ class LH5Store:
         return utils.read_n_rows(name, self.gimme_file(lh5_file, "r"))
 
     def read_size_in_bytes(self, name: str, lh5_file: str | h5py.File) -> int:
-        """Look up the size (in B) of the object. Will recursively crawl
-        through all objects in a Struct or Table
+        """Look up the size (in B) of the object in memory. Will recursively
+        crawl through all objects in a Struct or Table
         """
         return utils.read_size_in_bytes(name, self.gimme_file(lh5_file, "r"))

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -54,6 +54,7 @@ def read_n_rows(name: str, h5f: str | h5py.File) -> int | None:
 
     return _serializers.read.utils.read_n_rows(h5o, h5f.name, name)
 
+
 def read_size_in_bytes(name: str, h5f: str | h5py.File) -> int | None:
     """Look up the size (in B) in an LGDO object on disk. Will crawl
     recursively through members of a Struct or Table

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -54,6 +54,21 @@ def read_n_rows(name: str, h5f: str | h5py.File) -> int | None:
 
     return _serializers.read.utils.read_n_rows(h5o, h5f.name, name)
 
+def read_size_in_bytes(name: str, h5f: str | h5py.File) -> int | None:
+    """Look up the size (in B) in an LGDO object on disk. Will crawl
+    recursively through members of a Struct or Table
+    """
+    if not isinstance(h5f, h5py.File):
+        h5f = h5py.File(h5f, "r", locking=False)
+
+    try:
+        h5o = h5f[name].id
+    except KeyError as e:
+        msg = "not found"
+        raise LH5DecodeError(msg, h5f, name) from e
+
+    return _serializers.read.utils.read_size_in_bytes(h5o, h5f.name, name)
+
 
 def get_h5_group(
     group: str | h5py.Group,

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -12,7 +12,7 @@ from typing import Any
 import h5py
 
 from .. import types
-from . import _serializers, datatype
+from . import _serializers
 from .exceptions import LH5DecodeError
 
 log = logging.getLogger(__name__)
@@ -47,54 +47,12 @@ def read_n_rows(name: str, h5f: str | h5py.File) -> int | None:
         h5f = h5py.File(h5f, "r")
 
     try:
-        attrs = h5f[name].attrs
+        h5o = h5f[name].id
     except KeyError as e:
         msg = "not found"
         raise LH5DecodeError(msg, h5f, name) from e
-    except AttributeError as e:
-        msg = "missing 'datatype' attribute"
-        raise LH5DecodeError(msg, h5f, name) from e
 
-    lgdotype = datatype.datatype(attrs["datatype"])
-
-    # scalars are dim-0 datasets
-    if lgdotype is types.Scalar:
-        return None
-
-    # structs don't have rows
-    if lgdotype is types.Struct:
-        return None
-
-    # tables should have elements with all the same length
-    if lgdotype is types.Table:
-        # read out each of the fields
-        rows_read = None
-        for field in datatype.get_struct_fields(attrs["datatype"]):
-            n_rows_read = read_n_rows(name + "/" + field, h5f)
-            if not rows_read:
-                rows_read = n_rows_read
-            elif rows_read != n_rows_read:
-                log.warning(
-                    f"'{field}' field in table '{name}' has {rows_read} rows, "
-                    f"{n_rows_read} was expected"
-                )
-        return rows_read
-
-    # length of vector of vectors is the length of its cumulative_length
-    if lgdotype is types.VectorOfVectors:
-        return read_n_rows(f"{name}/cumulative_length", h5f)
-
-    # length of vector of encoded vectors is the length of its decoded_size
-    if lgdotype in (types.VectorOfEncodedVectors, types.ArrayOfEncodedEqualSizedArrays):
-        return read_n_rows(f"{name}/encoded_data", h5f)
-
-    # return array length (without reading the array!)
-    if issubclass(lgdotype, types.Array):
-        # compute the number of rows to read
-        return h5f[name].shape[0]
-
-    msg = f"don't know how to read rows of LGDO {lgdotype.__name__}"
-    raise LH5DecodeError(msg, h5f, name)
+    return _serializers.read.utils.read_n_rows(h5o, h5f.name, name)
 
 
 def get_h5_group(

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -44,7 +44,7 @@ def read_n_rows(name: str, h5f: str | h5py.File) -> int | None:
     Return ``None`` if `name` is a :class:`.Scalar` or a :class:`.Struct`.
     """
     if not isinstance(h5f, h5py.File):
-        h5f = h5py.File(h5f, "r")
+        h5f = h5py.File(h5f, "r", locking=False)
 
     try:
         h5o = h5f[name].id

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -56,7 +56,7 @@ def read_n_rows(name: str, h5f: str | h5py.File) -> int | None:
 
 
 def read_size_in_bytes(name: str, h5f: str | h5py.File) -> int | None:
-    """Look up the size (in B) in an LGDO object on disk. Will crawl
+    """Look up the size (in B) in an LGDO object in memory. Will crawl
     recursively through members of a Struct or Table
     """
     if not isinstance(h5f, h5py.File):

--- a/src/lgdo/types/histogram.py
+++ b/src/lgdo/types/histogram.py
@@ -324,7 +324,7 @@ class Histogram(Struct):
         assert all(isinstance(v, Histogram.Axis) for k, v in bins)
         return tuple(v for _, v in bins)
 
-    def fill(self, data, w: np.ndarray = None, keys: List[str] = None) -> None:
+    def fill(self, data, w: np.ndarray = None, keys: list[str] = None) -> None:
         """Fill histogram by incrementing bins with data points weighted by w
 
         Parameters

--- a/src/lgdo/types/histogram.py
+++ b/src/lgdo/types/histogram.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence, Mapping
 from typing import Any
 
 import hist
 import numpy as np
+import pandas as pd
 from numpy.typing import NDArray
 
 from .array import Array
@@ -269,10 +270,10 @@ class Histogram(Struct):
                     b.append(Histogram.Axis.from_edges(ax.edges, binedge_attrs))
         else:
             if binning is None:
-                msg = "need to also pass binning if passing histogram as array"
+                msg = "need to pass binning to construct Histogram"
                 raise ValueError(msg)
-            w = weights if isinstance(weights, Array) else Array(weights)
 
+            # set up binning
             if all(isinstance(ax, Histogram.Axis) for ax in binning):
                 if binedge_attrs is not None:
                     msg = "passed both binedges as Axis instances and binedge_attrs"
@@ -285,6 +286,14 @@ class Histogram(Struct):
             else:
                 msg = "invalid binning object passed"
                 raise ValueError(msg)
+
+            # set up bin weights
+            if isinstance(weights, Array):
+                w = weights
+            elif weights is None:
+                w = Array(shape=[ax.nbins for ax in b], fill_val=0, dtype="float32")
+            else:
+                w = Array(weights)
 
             if len(binning) != len(w.nda.shape):
                 msg = "binning and weight dimensions do not match"
@@ -314,6 +323,69 @@ class Histogram(Struct):
         bins = sorted(self["binning"].items())
         assert all(isinstance(v, Histogram.Axis) for k, v in bins)
         return tuple(v for _, v in bins)
+
+    def fill(self, data, w: np.ndarray = None, keys:List[str] = None) -> None:
+        """Fill histogram by incrementing bins with data points weighted by w
+
+        Parameters
+        ----------
+        data
+            a ndarray with inner dimension equal to number of axes or a list
+            of equal-length 1d-arrays containing data for each axis
+        w
+            weight to use for incrementing data points. If None, use 1 for all
+        """
+        if isinstance(data, np.ndarray) and len(data.shape)==1 and len(self.binning)==1:
+            N = len(data)
+            data = [data]
+        elif isinstance(data, np.ndarray) and len(data.shape)==2 and data.shape[1]==len(self.binning):
+            N = data.shape[0]
+            data = data.T
+        elif isinstance(data, pd.DataFrame) and data.ndim==len(self.binning):
+            if keys is not None:
+                data = data[keys]
+            N = len(data)
+            data = data.values.T
+        elif isinstance(data, Sequence) and len(data)==len(self.binning):
+            data = [d if isinstance(d, np.ndarray) else np.array(d) for d in data]
+            N = len(data[0])
+            if not all(len(d)==N for d in data):
+                msg = "length of all data arrays must be equal"
+                raise ValueError(msg)
+        elif isinstance(data, Mapping) and len(data)==len(self.binning):
+            if not isinstance(keys, Sequence):
+                msg = "filling hist with Mapping data requires a list of keys"
+                raise ValueError(msg)
+            data = [data[k] if isinstance(data[k], np.ndarray) else np.array(data[k]) for k in keys]
+            N = len(data[0])
+            if not all(len(d)==N for d in data):
+                msg = "length of all data arrays must be equal"
+                raise ValueError(msg)
+        else:
+            msg = "data must be 2D numpy array or list of 1D arrays with length equal to number of axes"
+            raise ValueError(msg)
+
+        idx = np.zeros(N, "float64") # bin indices for flattened array
+        oor_mask = np.ones(N, "bool") # mask for out of range values
+        stride = [s//self.weights.dtype.itemsize for s in self.weights.nda.strides]
+        for col, ax, s in zip(data, self.binning, stride):
+            if ax.is_range:
+                np.add(idx, s*np.floor((col - ax.first)/ax.step - int(not ax.closedleft)), idx)
+                if ax.closedleft:
+                    oor_mask &= ( (ax.first <= col) & (col < ax.last) )
+                else:
+                    oor_mask &= ( (ax.first < col) & (col <= ax.last) )
+            else:
+                idx += s*(np.searchsorted(ax.edges, col, side=("right" if ax.closedleft else "left")) - 1)
+                if ax.closedleft:
+                    oor_mask &= ( (ax.edges[0] <= col) & (col < ax.edges[-1]) )
+                else:
+                    oor_mask &= ( (ax.edges[0] < col) & (col <= ax.edges[-1]) )
+
+        # increment bin contents
+        idx = idx[oor_mask].astype('int64')
+        w = w[oor_mask] if w is not None else 1
+        np.add.at(self.weights.nda.reshape(-1), idx, w)
 
     def __setitem__(self, name: str, obj: LGDO) -> None:
         # do not allow for new attributes on this

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -450,7 +450,7 @@ class Table(Struct):
             cols = self.keys()
 
         if library == "pd":
-            df = pd.DataFrame()
+            df = {}
 
             for col in cols:
                 data = self[col]
@@ -470,7 +470,7 @@ class Table(Struct):
                     )
                     df[f"{prefix}{col}"] = data.view_as("pd", with_units=with_units)
 
-            return df
+            return pd.DataFrame(df, copy=False)
 
         if library == "np":
             msg = f"Format {library!r} is not supported for Tables."

--- a/src/lgdo/types/vectorofvectors.py
+++ b/src/lgdo/types/vectorofvectors.py
@@ -632,7 +632,7 @@ class VectorOfVectors(LGDO):
             offsets = np.empty(
                 len(self.cumulative_length) + 1, dtype=self.cumulative_length.dtype
             )
-            offsets[1:] = self.cumulative_length
+            offsets[1:] = self.cumulative_length.nda
             offsets[0] = 0
 
             content = (

--- a/tests/lh5/test_lh5_iterator.py
+++ b/tests/lh5/test_lh5_iterator.py
@@ -36,6 +36,7 @@ def test_basics(lgnd_file):
         assert n_rows == 5
         assert entry % 5 == 0
         assert all(lh5_it.current_local_entries == np.arange(entry, entry + 5))
+        assert all(lh5_it.current_global_entries == np.arange(entry, entry + 5))
         assert all(lh5_it.current_files == [lgnd_file] * 5)
         assert all(lh5_it.current_groups == ["/geds/raw"] * 5)
 
@@ -144,7 +145,8 @@ def test_iterate(more_lgnd_files):
         buffer_len=5,
     )
 
-    exp_entries = [[0, 1, 2, 3, 5], [8, 3, 1, 4, 5]]
+    exp_loc_entries = [[0, 1, 2, 3, 5], [8, 3, 1, 4, 5]]
+    exp_glob_entries = [[0, 1, 2, 3, 5], [8, 13, 21, 34, 55]]
     exp_files = [
         [more_lgnd_files[1][0]] * 5,
         [more_lgnd_files[1][0]] * 3 + [more_lgnd_files[1][1]] * 2,
@@ -164,7 +166,8 @@ def test_iterate(more_lgnd_files):
         assert set(lh5_out.keys()) == {"is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"}
         assert entry % 5 == 0
         assert n_rows == 5
-        assert all(lh5_it.current_local_entries == exp_entries[entry // 5])
+        assert all(lh5_it.current_local_entries == exp_loc_entries[entry // 5])
+        assert all(lh5_it.current_global_entries == exp_glob_entries[entry // 5])
         assert all(lh5_it.current_files == exp_files[entry // 5])
         assert all(lh5_it.current_groups == exp_groups[entry // 5])
 

--- a/tests/lh5/test_lh5_iterator.py
+++ b/tests/lh5/test_lh5_iterator.py
@@ -35,6 +35,9 @@ def test_basics(lgnd_file):
         assert len(lh5_obj) == 5
         assert n_rows == 5
         assert entry % 5 == 0
+        assert all(lh5_it.current_local_entries == np.arange(entry, entry + 5))
+        assert all(lh5_it.current_files == [lgnd_file] * 5)
+        assert all(lh5_it.current_groups == ["/geds/raw"] * 5)
 
 
 def test_errors(lgnd_file):
@@ -141,10 +144,29 @@ def test_iterate(more_lgnd_files):
         buffer_len=5,
     )
 
+    exp_entries = [[0, 1, 2, 3, 5], [8, 3, 1, 4, 5]]
+    exp_files = [
+        [more_lgnd_files[1][0]] * 5,
+        [more_lgnd_files[1][0]] * 3 + [more_lgnd_files[1][1]] * 2,
+    ]
+    exp_groups = [
+        ["ch1084803/hit"] * 5,
+        [
+            "ch1084803/hit",
+            "ch1084804/hit",
+            "ch1121600/hit",
+            "ch1084803/hit",
+            "ch1121600/hit",
+        ],
+    ]
+
     for lh5_out, entry, n_rows in lh5_it:
         assert set(lh5_out.keys()) == {"is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"}
         assert entry % 5 == 0
         assert n_rows == 5
+        assert all(lh5_it.current_local_entries == exp_entries[entry // 5])
+        assert all(lh5_it.current_files == exp_files[entry // 5])
+        assert all(lh5_it.current_groups == exp_groups[entry // 5])
 
     lh5_it = lh5.LH5Iterator(
         more_lgnd_files[1],

--- a/tests/lh5/test_lh5_store.py
+++ b/tests/lh5/test_lh5_store.py
@@ -54,17 +54,21 @@ def test_read_n_rows(lh5_file):
     assert store.read_n_rows("/data/struct_full/wftable", lh5_file) == 10
     assert store.read_n_rows("/data/struct_full/wftable_enc/values", lh5_file) == 10
 
+
 def test_read_size_in_bytes(lh5_file):
     store = lh5.LH5Store()
     assert store.read_size_in_bytes("/data/struct_full/aoesa", lh5_file) == 100
     assert store.read_size_in_bytes("/data/struct_full/array", lh5_file) == 40
     assert store.read_size_in_bytes("/data/struct_full/scalar", lh5_file) == 8
     assert store.read_size_in_bytes("/data/struct_full/table", lh5_file) == 128
-    #assert store.read_size_in_bytes("/data/struct_full/voev", lh5_file) == ?
+    # assert store.read_size_in_bytes("/data/struct_full/voev", lh5_file) == ?
     assert store.read_size_in_bytes("/data/struct_full/vov", lh5_file) == 144
     assert store.read_size_in_bytes("/data/struct_full/vov3d", lh5_file) == 232
     assert store.read_size_in_bytes("/data/struct_full/wftable", lh5_file) == 20160
-    assert store.read_size_in_bytes("/data/struct_full/wftable_enc", lh5_file) == 80+80+40000
+    assert (
+        store.read_size_in_bytes("/data/struct_full/wftable_enc", lh5_file)
+        == 80 + 80 + 40000
+    )
 
 
 def test_get_buffer(lh5_file):

--- a/tests/lh5/test_lh5_store.py
+++ b/tests/lh5/test_lh5_store.py
@@ -54,6 +54,18 @@ def test_read_n_rows(lh5_file):
     assert store.read_n_rows("/data/struct_full/wftable", lh5_file) == 10
     assert store.read_n_rows("/data/struct_full/wftable_enc/values", lh5_file) == 10
 
+def test_read_size_in_bytes(lh5_file):
+    store = lh5.LH5Store()
+    assert store.read_size_in_bytes("/data/struct_full/aoesa", lh5_file) == 100
+    assert store.read_size_in_bytes("/data/struct_full/array", lh5_file) == 40
+    assert store.read_size_in_bytes("/data/struct_full/scalar", lh5_file) == 8
+    assert store.read_size_in_bytes("/data/struct_full/table", lh5_file) == 128
+    #assert store.read_size_in_bytes("/data/struct_full/voev", lh5_file) == ?
+    assert store.read_size_in_bytes("/data/struct_full/vov", lh5_file) == 144
+    assert store.read_size_in_bytes("/data/struct_full/vov3d", lh5_file) == 232
+    assert store.read_size_in_bytes("/data/struct_full/wftable", lh5_file) == 20160
+    assert store.read_size_in_bytes("/data/struct_full/wftable_enc", lh5_file) == 80+80+40000
+
 
 def test_get_buffer(lh5_file):
     store = lh5.LH5Store()

--- a/tests/types/test_histogram.py
+++ b/tests/types/test_histogram.py
@@ -298,66 +298,90 @@ def test_read_histogram_multiple(lgnd_test_data):
     with pytest.raises(LH5DecodeError):
         lh5.read("test_histogram_range", [file, file])
 
+
 def test_histogram_fill(lgnd_test_data):
     # Test the basics with fixed width bins
-    h = Histogram(None, [ (0, 5, 1) ])
-    h.fill(np.array([0.5, 1.5, 1.1])) # add some data
-    assert all(h.weights.nda == np.array([1., 2., 0., 0., 0.]))
-    h.fill(np.array([0.5, 3.5, 4., 3.5])) # add more data
-    assert all(h.weights.nda == np.array([2., 2., 0., 2., 1.]))
-    h.fill(np.array([-1., 6., np.inf, np.nan])) # add out of range data
-    assert all(h.weights.nda == np.array([2., 2., 0., 2., 1.]))
+    h = Histogram(None, [(0, 5, 1)])
+    h.fill(np.array([0.5, 1.5, 1.1]))  # add some data
+    assert all(h.weights.nda == np.array([1.0, 2.0, 0.0, 0.0, 0.0]))
+    h.fill(np.array([0.5, 3.5, 4.0, 3.5]))  # add more data
+    assert all(h.weights.nda == np.array([2.0, 2.0, 0.0, 2.0, 1.0]))
+    h.fill(np.array([-1.0, 6.0, np.inf, np.nan]))  # add out of range data
+    assert all(h.weights.nda == np.array([2.0, 2.0, 0.0, 2.0, 1.0]))
 
     # Test the basics with variable width bins
-    h = Histogram(None, [ np.array([0., 0.75, 2., 4., 4.5, 5.]) ])
-    h.fill(np.array([0.5, 1.5, 1.1])) # add some data
-    assert all(h.weights.nda == np.array([1., 2., 0., 0., 0.]))
-    h.fill(np.array([0.5, 3.5, 4., 3.5])) # add more data
-    assert all(h.weights.nda == np.array([2., 2., 2., 1., 0.]))
-    h.fill(np.array([-1., 6., np.inf, np.nan])) # add out of range data
-    assert all(h.weights.nda == np.array([2., 2., 2., 1., 0.]))
-    
+    h = Histogram(None, [np.array([0.0, 0.75, 2.0, 4.0, 4.5, 5.0])])
+    h.fill(np.array([0.5, 1.5, 1.1]))  # add some data
+    assert all(h.weights.nda == np.array([1.0, 2.0, 0.0, 0.0, 0.0]))
+    h.fill(np.array([0.5, 3.5, 4.0, 3.5]))  # add more data
+    assert all(h.weights.nda == np.array([2.0, 2.0, 2.0, 1.0, 0.0]))
+    h.fill(np.array([-1.0, 6.0, np.inf, np.nan]))  # add out of range data
+    assert all(h.weights.nda == np.array([2.0, 2.0, 2.0, 1.0, 0.0]))
+
     # Test bin edge behavior with fixed width bins
-    h = Histogram(None, [ Histogram.Axis(None, 0, 6, 1, closedleft=True) ])
+    h = Histogram(None, [Histogram.Axis(None, 0, 6, 1, closedleft=True)])
     h.fill(np.array([0, 2, 4, 6]))
-    assert all(h.weights.nda == np.array([1., 0., 1., 0., 1., 0.]))
-    h = Histogram(None, [ Histogram.Axis(None, 0, 6, 1, closedleft=False) ])
+    assert all(h.weights.nda == np.array([1.0, 0.0, 1.0, 0.0, 1.0, 0.0]))
+    h = Histogram(None, [Histogram.Axis(None, 0, 6, 1, closedleft=False)])
     h.fill(np.array([0, 2, 4, 6]))
-    assert all(h.weights.nda == np.array([0., 1., 0., 1., 0., 1.]))
-    
+    assert all(h.weights.nda == np.array([0.0, 1.0, 0.0, 1.0, 0.0, 1.0]))
+
     # Test bin edge behavior with variable width bins
-    h = Histogram(None, [ Histogram.Axis([0., 0.75, 2., 4., 4.5, 5., 6.], None, None, None, closedleft=True) ])
+    h = Histogram(
+        None,
+        [
+            Histogram.Axis(
+                [0.0, 0.75, 2.0, 4.0, 4.5, 5.0, 6.0], None, None, None, closedleft=True
+            )
+        ],
+    )
     h.fill(np.array([0, 2, 4, 6]))
-    assert all(h.weights.nda == np.array([1., 0., 1., 1., 0., 0.]))
-    h = Histogram(None, [ Histogram.Axis([0., 0.75, 2., 4., 4.5, 5., 6.], None, None, None, closedleft=False) ])
+    assert all(h.weights.nda == np.array([1.0, 0.0, 1.0, 1.0, 0.0, 0.0]))
+    h = Histogram(
+        None,
+        [
+            Histogram.Axis(
+                [0.0, 0.75, 2.0, 4.0, 4.5, 5.0, 6.0], None, None, None, closedleft=False
+            )
+        ],
+    )
     h.fill(np.array([0, 2, 4, 6]))
-    assert all(h.weights.nda == np.array([0., 1., 1., 0., 0., 1.]))
-    
+    assert all(h.weights.nda == np.array([0.0, 1.0, 1.0, 0.0, 0.0, 1.0]))
+
     # Test 2d histogram with numpy array data
-    h = Histogram(None, [ (0, 3, 1), (0, 3, 1) ])
-    data = np.array( [ [1, 1], [2, 2], [-1, 2], [2, -1] ])
+    h = Histogram(None, [(0, 3, 1), (0, 3, 1)])
+    data = np.array([[1, 1], [2, 2], [-1, 2], [2, -1]])
     h.fill(data)
-    assert np.all(h.weights.nda == np.array([[0., 0., 0.], [0., 1., 0.], [0., 0., 1.]]))
-    
+    assert np.all(
+        h.weights.nda == np.array([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    )
+
     # Test 2d histogram with pandas data
-    h = Histogram(None, [ (0, 3, 1), (0, 3, 1) ])
+    h = Histogram(None, [(0, 3, 1), (0, 3, 1)])
     data = pd.DataFrame({"a": [1, 2, -1, 2], "b": [1, 2, 2, -1]})
     h.fill(data)
-    assert np.all(h.weights.nda == np.array([[0., 0., 0.], [0., 1., 0.], [0., 0., 1.]]))
+    assert np.all(
+        h.weights.nda == np.array([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    )
     h.fill(data, keys=["a", "b"])
-    assert np.all(h.weights.nda == np.array([[0., 0., 0.], [0., 2., 0.], [0., 0., 2.]]))
-    
+    assert np.all(
+        h.weights.nda == np.array([[0.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 2.0]])
+    )
+
     # Test list of columnar data
-    h = Histogram(None, [ (0, 3, 1), (0, 3, 1) ])
+    h = Histogram(None, [(0, 3, 1), (0, 3, 1)])
     data = [np.array([1, 2, -1, 2]), np.array([1, 2, 2, -1])]
     h.fill(data)
-    assert np.all(h.weights.nda == np.array([[0., 0., 0.], [0., 1., 0.], [0., 0., 1.]]))
+    assert np.all(
+        h.weights.nda == np.array([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    )
 
     # Test ordered dict of columnar data
-    h = Histogram(None, [ (0, 3, 1), (0, 3, 1) ])
+    h = Histogram(None, [(0, 3, 1), (0, 3, 1)])
     data = {"a": [1, 2, -1, 2], "b": [1, 2, 2, -1]}
     with pytest.raises(ValueError, match="requires a list of keys"):
         h.fill(data)
     h.fill(data, keys=["a", "b"])
-    assert np.all(h.weights.nda == np.array([[0., 0., 0.], [0., 1., 0.], [0., 0., 1.]]))
-    
+    assert np.all(
+        h.weights.nda == np.array([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    )

--- a/tests/types/test_histogram.py
+++ b/tests/types/test_histogram.py
@@ -375,6 +375,8 @@ def test_histogram_fill():
     assert np.all(
         h.weights.nda == np.array([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     )
+    with pytest.raises(ValueError, match="length of all data arrays"):
+        h.fill([np.array([1, 2, -1]), np.array([1, 2, 2, -1])])
 
     # Test ordered dict of columnar data
     h = Histogram(None, [(0, 3, 1), (0, 3, 1)])
@@ -385,3 +387,8 @@ def test_histogram_fill():
     assert np.all(
         h.weights.nda == np.array([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     )
+    with pytest.raises(ValueError, match="length of all data arrays"):
+        h.fill({"a": [1, 2, -1], "b": [1, 2, 2, -1]}, keys=["a", "b"])
+
+    with pytest.raises(ValueError, match="data must be"):
+        h.fill(np.ones(shape=(5, 5)))

--- a/tests/types/test_histogram.py
+++ b/tests/types/test_histogram.py
@@ -299,7 +299,7 @@ def test_read_histogram_multiple(lgnd_test_data):
         lh5.read("test_histogram_range", [file, file])
 
 
-def test_histogram_fill(lgnd_test_data):
+def test_histogram_fill():
     # Test the basics with fixed width bins
     h = Histogram(None, [(0, 5, 1)])
     h.fill(np.array([0.5, 1.5, 1.1]))  # add some data


### PR DESCRIPTION
- Replaced recursion in two functions in LH5Iterator with loops to avoid a recursion depth error
- Added ability to use integer value of keep_open with LH5Store so that it only caches the n most recently accessed files. Luckily OrderedDict was perfect for the job
- LH5Iterator only caches 3 files at a time to avoid using large amounts of memory when opening a huge number of files