### PR TITLE
Nested field mask

### DIFF
--- a/src/lgdo/lh5/_serializers/read/composite.py
+++ b/src/lgdo/lh5/_serializers/read/composite.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import bisect
 import logging
 import sys
-from collections import defaultdict
 
 import h5py
 import numpy as np
@@ -72,19 +71,8 @@ def _h5_read_lgdo(
             obj_buf=obj_buf,
         )
 
-    # check field_mask and make it a default dict
-    if field_mask is None:
-        field_mask = defaultdict(lambda: True)
-    elif isinstance(field_mask, dict):
-        default = True
-        if len(field_mask) > 0:
-            default = not field_mask[next(iter(field_mask.keys()))]
-        field_mask = defaultdict(lambda: default, field_mask)
-    elif isinstance(field_mask, (list, tuple, set)):
-        field_mask = defaultdict(bool, {field: True for field in field_mask})
-    elif not isinstance(field_mask, defaultdict):
-        msg = "bad field_mask type"
-        raise ValueError(msg, type(field_mask).__name__)
+    # Convert whatever we input into a defaultdict
+    field_mask = utils.build_field_mask(field_mask)
 
     if lgdotype is Struct:
         return _h5_read_struct(

--- a/src/lgdo/lh5/_serializers/read/composite.py
+++ b/src/lgdo/lh5/_serializers/read/composite.py
@@ -237,7 +237,9 @@ def _h5_read_struct(
     selected_fields = utils.eval_field_mask(field_mask, all_fields)
 
     # modify datatype in attrs if a field_mask was used
-    attrs["datatype"] = "struct{" + ",".join(field for field, _ in selected_fields) + "}"
+    attrs["datatype"] = (
+        "struct{" + ",".join(field for field, _ in selected_fields) + "}"
+    )
 
     # loop over fields and read
     obj_dict = {}

--- a/src/lgdo/lh5/_serializers/read/utils.py
+++ b/src/lgdo/lh5/_serializers/read/utils.py
@@ -53,8 +53,8 @@ def eval_field_mask(
     this_field_mask = defaultdict(field_mask.default_factory)
     sub_field_masks = {}
 
-    for field, val in field_mask.items():
-        field = field.strip("/")
+    for key, val in field_mask.items():
+        field = key.strip("/")
         pos = field.find("/")
         if pos < 0:
             this_field_mask[field] = val


### PR DESCRIPTION
Added ability to provide nested field masks (e.g. in `evt` tier, can do `field_mask=["trigger", "geds/multiplicity", "geds/quality/is_not_bb_like", "coincident"]`