### PR TITLE
lh5concat: allow concatenating of group-like structs

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -149,3 +149,21 @@ def test_lh5concat(lgnd_test_data, tmptestdir):
         assert tbl.packet_id[i] == tbl2.packet_id[i - 10]
         assert np.array_equal(tbl.tracelist[i], tbl2.tracelist[i - 10])
         assert np.array_equal(tbl.waveform.values[i], tbl2.waveform.values[i - 10])
+
+    # test concatenating arrays in structs.
+    infile1 = f"{tmptestdir}/concat_test_struct_0.lh5"
+    tb1 = types.Table(col_dict={"col": types.Array(np.zeros(4))})
+    struct1 = types.Struct({"x": tb1})
+    store.write(struct1, "stp", infile1, wo_mode="overwrite_file")
+
+    infile2 = f"{tmptestdir}/concat_test_struct_1.lh5"
+    tb2 = types.Table(col_dict={"col": types.Array(np.ones(7))})
+    struct2 = types.Struct({"x": tb2})
+    store.write(struct2, "stp", infile2, wo_mode="overwrite_file")
+
+    outfile = f"{tmptestdir}/concat_test_struct_out.lh5"
+    cli.lh5concat(["--output", outfile, "--", infile1, infile2])
+
+    out_stp = store.read("stp", outfile)[0]
+    assert out_stp.attrs["datatype"] == "struct{x}"
+    assert np.all(out_stp.x["col"].nda == np.array([0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1]))


### PR DESCRIPTION
"fixes" #119

this does not (yet) have a general fix as it only warns about a known "blacklist" of unmergeable data.