### PR TITLE
fix reading of vlen strings

### DIFF
--- a/src/lgdo/utils.py
+++ b/src/lgdo/utils.py
@@ -52,7 +52,7 @@ def get_element_type(obj: object) -> str:
     if (
         kind == "O"
         and dt.metadata is not None
-        and dt.metadata.get("vlen", None) is not None
+        and dt.metadata.get("vlen", None) in (str, bytes)
     ):
         # variable length strings in HDF5 are read as numpy object arrays in h5py.
         # see also h5py.check_vlen_dtype.

--- a/src/lgdo/utils.py
+++ b/src/lgdo/utils.py
@@ -49,6 +49,14 @@ def get_element_type(obj: object) -> str:
         return "complex"
     if kind in ["S", "U"]:
         return "string"
+    if (
+        kind == "O"
+        and dt.metadata is not None
+        and dt.metadata.get("vlen", None) is not None
+    ):
+        # variable length strings in HDF5 are read as numpy object arrays in h5py.
+        # see also h5py.check_vlen_dtype.
+        return "string"
 
     # couldn't figure it out
     msg = "cannot determine lgdo element_type for object of type"

--- a/tests/test_lgdo_utils.py
+++ b/tests/test_lgdo_utils.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import h5py
 import numpy as np
 
 from lgdo import utils
 
 
 def test_get_element_type():
+    # variable length HD5 string datatype.
+    h5py_str_dtype = h5py.string_dtype(encoding="ascii", length=None)
+
     objs = [
         ("hi", "string"),
         (True, "bool"),
@@ -16,6 +20,7 @@ def test_get_element_type():
         (1 + 1j, "complex"),
         (b"hi", "string"),
         (np.array(["hi"]), "string"),
+        (np.array([b"hi"], h5py_str_dtype), "string"),
     ]
 
     for obj, name in objs:


### PR DESCRIPTION
Geant4 writes strings as variable length datatype, and they end up in LH5 files via the `remage-to-lh5` conversion.

h5py reads them as object arrays, and attaches a `vlen` metadata property, so return a string datatype in this case.