### PR TITLE
Fixed bug when reading empty object buffer with empty idx list

### DIFF
--- a/src/lgdo/lh5/_serializers/read/vector_of_vectors.py
+++ b/src/lgdo/lh5/_serializers/read/vector_of_vectors.py
@@ -189,7 +189,7 @@ def _h5_read_vector_of_vectors(
         # if the buffer is partially filled, cumulative_length will be invalid
         # (i.e. non monotonically increasing). Let's fix that but filling the
         # rest of the array with the length of flattened_data
-        if n_rows_read>0:
+        if n_rows_read > 0:
             end = obj_buf_start + n_rows_read
             obj_buf.cumulative_length.nda[end:] = obj_buf.cumulative_length.nda[end - 1]
 

--- a/src/lgdo/lh5/_serializers/read/vector_of_vectors.py
+++ b/src/lgdo/lh5/_serializers/read/vector_of_vectors.py
@@ -189,8 +189,9 @@ def _h5_read_vector_of_vectors(
         # if the buffer is partially filled, cumulative_length will be invalid
         # (i.e. non monotonically increasing). Let's fix that but filling the
         # rest of the array with the length of flattened_data
-        end = obj_buf_start + n_rows_read
-        obj_buf.cumulative_length.nda[end:] = obj_buf.cumulative_length.nda[end - 1]
+        if n_rows_read>0:
+            end = obj_buf_start + n_rows_read
+            obj_buf.cumulative_length.nda[end:] = obj_buf.cumulative_length.nda[end - 1]
 
         return obj_buf, n_rows_read
 

--- a/tests/lh5/test_lh5_store.py
+++ b/tests/lh5/test_lh5_store.py
@@ -292,6 +292,10 @@ def test_read_table_fancy_idx(lh5_file):
     assert isinstance(lh5_obj, types.Table)
     assert n_rows == 2
 
+    lh5_obj, n_rows = store.read("/data/struct/table", lh5_file, idx=[])
+    assert isinstance(lh5_obj, types.Table)
+    assert n_rows == 0
+
 
 def test_read_empty_struct(lh5_file):
     store = lh5.LH5Store()
@@ -468,6 +472,21 @@ def test_read_lgnd_vov_fancy_idx(lgnd_file):
     assert (lh5_obj.cumulative_length.nda == [1, 2, 3, 4, 5, 6, 7]).all()
     assert (lh5_obj.flattened_data.nda == [40, 60, 64, 60, 64, 28, 60]).all()
 
+    lh5_obj, n_rows = store.read(
+        "/geds/raw/tracelist", lgnd_file, idx=[]
+    )
+    assert isinstance(lh5_obj, types.VectorOfVectors)
+    assert n_rows == 0
+    assert len(lh5_obj) == 0
+
+
+    lh5_obj, n_rows = store.read(
+        "/geds/raw/tracelist", [lgnd_file]*3, idx=[250]
+    )
+    assert isinstance(lh5_obj, types.VectorOfVectors)
+    assert n_rows == 1
+    assert len(lh5_obj) == 1
+    
 
 def test_read_array_concatenation(lgnd_file):
     store = lh5.LH5Store()

--- a/tests/lh5/test_lh5_store.py
+++ b/tests/lh5/test_lh5_store.py
@@ -472,21 +472,16 @@ def test_read_lgnd_vov_fancy_idx(lgnd_file):
     assert (lh5_obj.cumulative_length.nda == [1, 2, 3, 4, 5, 6, 7]).all()
     assert (lh5_obj.flattened_data.nda == [40, 60, 64, 60, 64, 28, 60]).all()
 
-    lh5_obj, n_rows = store.read(
-        "/geds/raw/tracelist", lgnd_file, idx=[]
-    )
+    lh5_obj, n_rows = store.read("/geds/raw/tracelist", lgnd_file, idx=[])
     assert isinstance(lh5_obj, types.VectorOfVectors)
     assert n_rows == 0
     assert len(lh5_obj) == 0
 
-
-    lh5_obj, n_rows = store.read(
-        "/geds/raw/tracelist", [lgnd_file]*3, idx=[250]
-    )
+    lh5_obj, n_rows = store.read("/geds/raw/tracelist", [lgnd_file] * 3, idx=[250])
     assert isinstance(lh5_obj, types.VectorOfVectors)
     assert n_rows == 1
     assert len(lh5_obj) == 1
-    
+
 
 def test_read_array_concatenation(lgnd_file):
     store = lh5.LH5Store()


### PR DESCRIPTION
Also added tests. This bug shows up when reading sparse data from a lot of files, if there are no indices in the first 2 or more files. See https://github.com/legend-exp/legend-pydataobj/issues/125