### PR TITLE
add the option to specify additional modules for Table.eval

### DIFF
--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -389,6 +389,10 @@ class Table(Struct):
         if np.isscalar(out_data):
             return Scalar(out_data)
 
+        # if out_data is already an LGDO just return it
+        if isinstance(out_data, LGDO):
+            return out_data
+
         msg = (
             f"evaluation resulted in a {type(out_data)} object, "
             "I don't know which LGDO this corresponds to"

--- a/tests/types/test_table_eval.py
+++ b/tests/types/test_table_eval.py
@@ -77,3 +77,7 @@ def test_eval_dependency():
     assert isinstance(r, lgdo.Scalar)
 
     assert obj.eval("np.sum(a) + ak.sum(e)")
+
+    # test with modules argument, the simplest is using directly lgdo
+    res = eval("lgdo.Array([1,2,3])", {}, {"lgdo": lgdo})
+    assert res == lgdo.Array([1, 2, 3])

--- a/tests/types/test_table_eval.py
+++ b/tests/types/test_table_eval.py
@@ -79,5 +79,5 @@ def test_eval_dependency():
     assert obj.eval("np.sum(a) + ak.sum(e)")
 
     # test with modules argument, the simplest is using directly lgdo
-    res = eval("lgdo.Array([1,2,3])", {}, {"lgdo": lgdo})
+    res = obj.eval("lgdo.Array([1,2,3])", {}, modules={"lgdo": lgdo})
     assert res == lgdo.Array([1, 2, 3])

--- a/tests/types/test_table_eval.py
+++ b/tests/types/test_table_eval.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hist
 import numpy as np
+import pytest
 
 import lgdo
 
@@ -31,6 +33,7 @@ def test_eval_dependency():
             ),
         }
     )
+
     r = obj.eval("sum(a)")
     assert isinstance(r, lgdo.Scalar)
 
@@ -81,3 +84,7 @@ def test_eval_dependency():
     # test with modules argument, the simplest is using directly lgdo
     res = obj.eval("lgdo.Array([1,2,3])", {}, modules={"lgdo": lgdo})
     assert res == lgdo.Array([1, 2, 3])
+
+    # check bad type
+    with pytest.raises(RuntimeError):
+        obj.eval("hist.Hist()", modules={"hist": hist})


### PR DESCRIPTION
Gives the possibility to specify additional modules to be used by `Table.eval`.
This functionality will be useful in reboost to simplify the evaluation also for reboost functions. 