### PR TITLE
Use numba for vectorofvectors to_aoesa

### DIFF
--- a/src/lgdo/types/vectorofvectors.py
+++ b/src/lgdo/types/vectorofvectors.py
@@ -13,6 +13,7 @@ import awkward as ak
 import awkward_pandas as akpd
 import numpy as np
 import pandas as pd
+from numba import jit
 from numpy.typing import ArrayLike, DTypeLike, NDArray
 
 from .. import utils
@@ -563,14 +564,14 @@ class VectorOfVectors(LGDO):
             ak_arr = self.view_as("ak")
 
             if max_len is None:
-                max_len = int(ak.max(ak.count(ak_arr, axis=-1)))
-
-            nda = ak.fill_none(
-                ak.pad_none(ak_arr, max_len, clip=True), fill_val
-            ).to_numpy(allow_missing=False)
-
+                lens = np.copy(self.cumulative_length)
+                lens[1:] = lens[1:] - lens[:-1]
+                max_len = int(ak.max(lens))
+            nda = np.full((len(self), max_len), fill_val)
             if preserve_dtype:
                 nda = nda.astype(self.flattened_data.dtype, copy=False)
+
+            _to_aoesa(self.flattened_data.nda, self.cumulative_length.nda, nda)
 
             return aoesa.ArrayOfEqualSizedArrays(nda=nda, attrs=self.getattrs())
 
@@ -664,3 +665,11 @@ class VectorOfVectors(LGDO):
 
         msg = f"{library} is not a supported third-party format."
         raise ValueError(msg)
+
+
+@jit
+def _to_aoesa(flattened_array, cumulative_length, nda):
+    prev_cl = 0
+    for i, cl in enumerate(cumulative_length):
+        nda[i, : (cl - prev_cl)] = flattened_array[prev_cl:cl]
+        prev_cl = cl

--- a/src/lgdo/types/vectorofvectors.py
+++ b/src/lgdo/types/vectorofvectors.py
@@ -561,12 +561,10 @@ class VectorOfVectors(LGDO):
             compatible one.
         """
         if self.ndim == 2:
-            ak_arr = self.view_as("ak")
-
             if max_len is None:
                 lens = np.copy(self.cumulative_length)
                 lens[1:] = lens[1:] - lens[:-1]
-                max_len = int(ak.max(lens))
+                max_len = int(np.max(lens))
             nda = np.full((len(self), max_len), fill_val)
             if preserve_dtype:
                 nda = nda.astype(self.flattened_data.dtype, copy=False)


### PR DESCRIPTION
Solves https://github.com/legend-exp/legend-pydataobj/issues/77

Using Louis's test:
```
read raw waveform_windowed  0.6720612049102783
read raw waveform_windowed  0.6306586265563965
read raw waveform_windowed  0.647637128829956
read raw waveform_windowed  0.6351368427276611
read raw waveform_windowed  0.6367087364196777
read raw waveform_presummed  1.0904109477996826
read raw waveform_presummed  1.084019422531128
read raw waveform_presummed  1.0867996215820312
read raw waveform_presummed  1.1002862453460693
read raw waveform_presummed  1.0836858749389648

read nocompression waveform_windowed  2.7566733360290527
read nocompression waveform_windowed  0.28818702697753906
read nocompression waveform_windowed  0.2825586795806885
read nocompression waveform_windowed  0.21329188346862793
read nocompression waveform_windowed  0.2136082649230957
read nocompression waveform_presummed  0.15611720085144043
read nocompression waveform_presummed  0.14903998374938965
read nocompression waveform_presummed  0.1486663818359375
read nocompression waveform_presummed  0.14964771270751953
read nocompression waveform_presummed  0.14685440063476562
...
read lzf waveform_windowed  1.5555720329284668
read lzf waveform_windowed  1.0727739334106445
read lzf waveform_windowed  1.1047019958496094
read lzf waveform_windowed  1.1058411598205566
read lzf waveform_windowed  1.1014294624328613
read lzf waveform_presummed  0.9572656154632568
read lzf waveform_presummed  0.7160823345184326
read lzf waveform_presummed  0.705615758895874
read lzf waveform_presummed  0.7134621143341064
read lzf waveform_presummed  0.7154068946838379
```