### PR TITLE
Make Struct datatype reproducible by sorting fields

### DIFF
--- a/src/lgdo/lh5/datatype.py
+++ b/src/lgdo/lh5/datatype.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from collections import OrderedDict
+from itertools import permutations as perm
 
 from .. import types as lgdo
 
@@ -14,7 +15,10 @@ _lgdo_datatype_map: dict[str, lgdo.LGDO] = OrderedDict(
             lgdo.ArrayOfEncodedEqualSizedArrays,
             r"^array_of_encoded_equalsized_arrays<1,1>\{.+\}$",
         ),
-        (lgdo.Histogram, r"^struct\{binning,weights,isdensity\}$"),
+        (
+            lgdo.Histogram,
+            rf"^struct\{{(?:{'|'.join([','.join(p) for p in perm(['binning', 'weights', 'isdensity'])])})\}}$",
+        ),
         (lgdo.Struct, r"^struct\{.*\}$"),
         (lgdo.Table, r"^table\{.*\}$"),
         (lgdo.FixedSizeArray, r"^fixedsize_array<\d+>\{.+\}$"),

--- a/src/lgdo/types/struct.py
+++ b/src/lgdo/types/struct.py
@@ -5,7 +5,9 @@ utilities.
 
 from __future__ import annotations
 
+import copy
 import logging
+import re
 from collections.abc import Mapping
 from typing import Any
 
@@ -56,7 +58,21 @@ class Struct(LGDO, dict):
                     # assign
                     super().update({k: v})
 
-        # call LGDO constructor to setup attributes
+        # check the datatype attribute passed by the user and sort the fields
+        # to ensure consistent behavior
+        if attrs is not None and "datatype" in attrs:
+            _attrs = copy.copy(dict(attrs))
+
+            if not _is_struct_datatype(self.datatype_name(), _attrs["datatype"]):
+                msg = (
+                    f"datatype attribute ({self.attrs['datatype']}) is not "
+                    f"compatible with class datatype!"
+                )
+                raise ValueError(msg)
+
+            _attrs["datatype"] = _sort_datatype_fields(_attrs["datatype"])
+            attrs = _attrs
+
         super().__init__(attrs)
 
     def datatype_name(self) -> str:
@@ -64,7 +80,10 @@ class Struct(LGDO, dict):
 
     def form_datatype(self) -> str:
         return (
-            self.datatype_name() + "{" + ",".join([str(k) for k in self.keys()]) + "}"
+            self.datatype_name()
+            + "{"
+            + ",".join(sorted([str(k) for k in self.keys()]))
+            + "}"
         )
 
     def update_datatype(self) -> None:
@@ -157,3 +176,34 @@ class Struct(LGDO, dict):
             "not possible. Call view_as() on the fields instead."
         )
         raise NotImplementedError(msg)
+
+
+def _is_struct_datatype(dt_name, expr):
+    return re.search("^" + dt_name + r"\{(.*)\}$", expr) is not None
+
+
+def _get_struct_fields(expr: str) -> list[str]:
+    assert _is_struct_datatype(".*", expr)
+
+    arr = re.search(r"\{(.*)\}$", expr).group(1).split(",")
+    if arr == [""]:
+        arr = []
+
+    return sorted(arr)
+
+
+def _struct_datatype_equal(dt_name, dt1, dt2):
+    if any(not _is_struct_datatype(dt_name, dt) for dt in (dt1, dt2)):
+        return False
+
+    return _get_struct_fields(dt1) == _get_struct_fields(dt2)
+
+
+def _sort_datatype_fields(expr):
+    assert _is_struct_datatype(".*", expr)
+
+    match = re.search(r"^(.*)\{.*\}$", expr)
+    struct_type = match.group(1)
+    fields = _get_struct_fields(expr)
+
+    return struct_type + "{" + ",".join(sorted([str(k) for k in fields])) + "}"

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -81,8 +81,9 @@ class Table(Struct, LGDOCollection):
             col_dict = _ak_to_lgdo_or_col_dict(col_dict)
 
         # call Struct constructor
-        Struct.__init__(self, obj_dict=col_dict)
-        LGDOCollection.__init__(self, attrs=attrs)
+        Struct.__init__(self, obj_dict=col_dict, attrs=attrs)
+        # no need to call the LGDOCollection constructor, as we are calling the
+        # Struct constructor already
 
         # if col_dict is not empty, set size according to it
         # if size is also supplied, resize all fields to match it

--- a/tests/lh5/test_lh5_write.py
+++ b/tests/lh5/test_lh5_write.py
@@ -452,6 +452,7 @@ def test_write_histogram(caplog, tmptestdir):
 
     # Now, check that the data were overwritten
     h3 = store.read("my_group/my_histogram", f"{tmptestdir}/write_histogram_test.lh5")
+    assert isinstance(h3, types.Histogram)
     assert np.array_equal(h3.weights.nda, np.array([[10, 10], [10, 10]]))
     assert h3.binning[0].edges[0] == 2
     assert h3.binning[1].edges[-1] == 7
@@ -518,6 +519,7 @@ def test_write_histogram_variable(caplog, tmptestdir):
 
     # Now, check that the data were overwritten
     h3 = store.read("my_group/my_histogram", f"{tmptestdir}/write_histogram_test.lh5")
+    assert isinstance(h3, types.Histogram)
     assert np.array_equal(h3.weights.nda, np.array([[10, 10], [10, 10]]))
     assert np.array_equal(h3.binning[0].edges, np.array([2, 3.5, 4]))
     with pytest.raises(TypeError):

--- a/tests/types/test_histogram.py
+++ b/tests/types/test_histogram.py
@@ -98,7 +98,7 @@ def test_init_np():
 def test_datatype_name():
     h = Histogram(np.array([1, 1]), (np.array([0, 1, 2]),))
     assert h.datatype_name() == "struct"
-    assert h.form_datatype() == "struct{binning,weights,isdensity}"
+    assert h.form_datatype() == "struct{binning,isdensity,weights}"
 
 
 def test_axes():
@@ -266,7 +266,7 @@ def test_view_as_np():
 
 def test_not_like_table():
     h = Histogram(np.array([1, 1]), (np.array([0, 1, 2]),))
-    assert h.form_datatype() == "struct{binning,weights,isdensity}"
+    assert h.form_datatype() == "struct{binning,isdensity,weights}"
     with pytest.raises(AttributeError):
         x = h.x  # noqa: F841
     with pytest.raises(AttributeError):

--- a/tests/types/test_struct.py
+++ b/tests/types/test_struct.py
@@ -58,10 +58,10 @@ def test_add_field():
     assert struct["scalar1"].__class__.__name__ == "Scalar"
 
     struct.add_field("array1", lgdo.Array(shape=(700, 21), dtype="f", fill_val=2))
-    assert struct.attrs["datatype"] == "struct{scalar1,array1}"
+    assert struct.attrs["datatype"] == "struct{array1,scalar1}"
 
     struct["array2"] = lgdo.Array(shape=(700, 21), dtype="f", fill_val=2)
-    assert struct.attrs["datatype"] == "struct{scalar1,array1,array2}"
+    assert struct.attrs["datatype"] == "struct{array1,array2,scalar1}"
 
 
 def test_getattr():

--- a/tests/types/test_waveformtable.py
+++ b/tests/types/test_waveformtable.py
@@ -12,7 +12,7 @@ def test_init():
     assert (wft.dt.nda == np.full(1024, fill_value=1)).all()
     assert isinstance(wft.values, lgdo.VectorOfVectors)
     assert len(wft.values) == 1024
-    assert wft.attrs == {"datatype": "table{t0,dt,values}"}
+    assert wft.attrs == {"datatype": "table{dt,t0,values}"}
 
     wft = WaveformTable(dt_units="ns", values_units="adc")
     assert wft.dt.attrs["units"] == "ns"


### PR DESCRIPTION
Changes:

- Structs and derived types will always build the datatype with sorted fields in memory. This means that it will be also written as such to disk
- If user passes the datatype to the Struct constructor, the constructor sorts fields before doing anything else
- When reading Structs from disk or comparing them, the ordering of fields is ignored

@ManuelHu I don't understand why histogram tests are failing, can you have a look?
