### PR TITLE
Fix usage of `DEFAULT_HDF5_SETTINGS` in user scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+.jupyter_ystore.db
 
 # IPython
 profile_default/

--- a/docs/source/notebooks/DataCompression.ipynb
+++ b/docs/source/notebooks/DataCompression.ipynb
@@ -103,7 +103,7 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "Looks like the data is compressed with [Gzip](http://www.gzip.org) (compression level 4) by default! This default setting is stored in the global `DEFAULT_HDF5_SETTINGS` variable:"
+    "Looks like the data is compressed with [Gzip](http://www.gzip.org) (compression level 4) by default! This default setting is stored in the global `lh5.settings.DEFAULT_HDF5_SETTINGS` variable:"
    ]
   },
   {
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lh5.DEFAULT_HDF5_SETTINGS"
+    "lh5.settings.DEFAULT_HDF5_SETTINGS"
    ]
   },
   {
@@ -121,7 +121,11 @@
    "id": "10",
    "metadata": {},
    "source": [
-    "Which specifies the default keyword arguments forwarded to [h5py.Group.create_dataset()](https://docs.h5py.org/en/stable/high/group.html#h5py.Group.create_dataset) and can be overridden by the user\n",
+    "Which specifies the default keyword arguments forwarded to [h5py.Group.create_dataset()](https://docs.h5py.org/en/stable/high/group.html#h5py.Group.create_dataset) and can be overridden by the user.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "**Important:** do not import `DEFAULT_HDF5_SETTINGS` in your namespace, import `lh5.settings` and modify `lh5.settings.DEFAULT_HDF5_SETTINGS`. Otherwise, changes won't have any effect.\n",
+    "</div>\n",
     "\n",
     "Examples:"
    ]
@@ -134,18 +138,18 @@
    "outputs": [],
    "source": [
     "# use another built-in filter\n",
-    "lh5.DEFAULT_HDF5_SETTINGS = {\"compression\": \"lzf\"}\n",
+    "lh5.settings.DEFAULT_HDF5_SETTINGS = {\"compression\": \"lzf\"}\n",
     "\n",
     "# specify filter name and options\n",
-    "lh5.DEFAULT_HDF5_SETTINGS = {\"compression\": \"gzip\", \"compression_opts\": 7}\n",
+    "lh5.settings.DEFAULT_HDF5_SETTINGS = {\"compression\": \"gzip\", \"compression_opts\": 7}\n",
     "\n",
     "# specify a registered filter provided by hdf5plugin\n",
     "import hdf5plugin\n",
     "\n",
-    "lh5.DEFAULT_HDF5_SETTINGS = {\"compression\": hdf5plugin.Blosc()}\n",
+    "lh5.settings.DEFAULT_HDF5_SETTINGS = {\"compression\": hdf5plugin.Blosc()}\n",
     "\n",
     "# shuffle bytes before compressing (typically better compression ratio with no performance penalty)\n",
-    "lh5.DEFAULT_HDF5_SETTINGS = {\"shuffle\": True, \"compression\": \"lzf\"}"
+    "lh5.settings.DEFAULT_HDF5_SETTINGS = {\"shuffle\": True, \"compression\": \"lzf\"}"
    ]
   },
   {
@@ -178,7 +182,9 @@
    "id": "14",
    "metadata": {},
    "source": [
-    "Nice. Shuffling bytes before compressing significantly reduced size on disk. Last but not least, `create_dataset()` keyword arguments can be passed to `write()`. They will be forwarded as is, overriding default settings."
+    "Nice. Shuffling bytes before compressing significantly reduced size on disk.\n",
+    "\n",
+    "To reset the HDF5 settings to default values:"
    ]
   },
   {
@@ -188,13 +194,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "lh5.settings.DEFAULT_HDF5_SETTINGS = lh5.settings.default_hdf5_settings()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "Last but not least, `create_dataset()` keyword arguments can be passed to `write()`. They will be forwarded as is, overriding default settings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "lh5.write(data, \"data\", \"data.lh5\", wo_mode=\"of\", shuffle=True, compression=\"gzip\")\n",
     "show_h5ds_opts(\"data/col1\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "18",
    "metadata": {},
    "source": [
     "Object-specific compression settings are supported via the `hdf5_settings` LGDO attribute:"
@@ -203,7 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "20",
    "metadata": {},
    "source": [
     "We are now storing table columns with different compression settings.\n",
@@ -229,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +262,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "22",
    "metadata": {},
    "source": [
     "## Waveform compression\n",
@@ -251,7 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +291,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "24",
    "metadata": {},
    "source": [
     "Let's encode the waveform values with the [RadwareSigcompress](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.compression.html#lgdo.compression.radware.RadwareSigcompress) codec.\n",
@@ -280,7 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,28 +316,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
-   "metadata": {},
-   "source": [
-    "The output LGDO is an [ArrayOfEncodedEqualSizedArrays](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.types.html#lgdo.types.encoded.ArrayOfEncodedEqualSizedArrays), which is basically an array of bytes representing the compressed data. How big is this compressed object in bytes?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "25",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "enc_values.encoded_data.flattened_data.nda.nbytes"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "26",
    "metadata": {},
    "source": [
-    "How big was the original data structure?"
+    "The output LGDO is an [ArrayOfEncodedEqualSizedArrays](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.types.html#lgdo.types.encoded.ArrayOfEncodedEqualSizedArrays), which is basically an array of bytes representing the compressed data. How big is this compressed object in bytes?"
    ]
   },
   {
@@ -323,12 +329,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wfs.values.nda.nbytes"
+    "enc_values.encoded_data.flattened_data.nda.nbytes"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "28",
+   "metadata": {},
+   "source": [
+    "How big was the original data structure?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wfs.values.nda.nbytes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30",
    "metadata": {},
    "source": [
     "It shrank quite a bit!\n",
@@ -339,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,7 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "32",
    "metadata": {},
    "source": [
     "The LH5 structure is more complex now. Note how the compression settings are stored as HDF5 attributes.\n",
@@ -369,7 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "34",
    "metadata": {},
    "source": [
     "Wait, this is not the compressed data we just wrote to disk, it got decompressed on the fly! It's still possible to just return the compressed data though:"
@@ -388,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +422,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "36",
    "metadata": {},
    "source": [
     "And then decompress it manually:"
@@ -407,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -418,7 +442,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "38",
    "metadata": {},
    "source": [
     "Waveform compression settings can also be specified at the LGDO level by attaching a `compression` attribute to the `values` attribute of a `WaveformTable` object:"
@@ -427,7 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +466,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "40",
    "metadata": {},
    "source": [
     "Further reading:\n",

--- a/src/lgdo/lh5/__init__.py
+++ b/src/lgdo/lh5/__init__.py
@@ -7,7 +7,6 @@ browsed easily in python like any `HDF5 <https://www.hdfgroup.org>`_ file using
 
 from __future__ import annotations
 
-from ._serializers.write.array import DEFAULT_HDF5_SETTINGS
 from .core import read, read_as, write
 from .iterator import LH5Iterator
 from .store import LH5Store
@@ -15,14 +14,15 @@ from .tools import ls, show
 from .utils import read_n_rows
 
 __all__ = [
-    "DEFAULT_HDF5_SETTINGS",
     "LH5Iterator",
     "LH5Store",
     "concat",
+    "default_hdf5_settings",
     "ls",
     "read",
     "read_as",
     "read_n_rows",
+    "reset_default_hdf5_settings",
     "show",
     "write",
 ]

--- a/src/lgdo/lh5/_serializers/write/array.py
+++ b/src/lgdo/lh5/_serializers/write/array.py
@@ -6,11 +6,10 @@ import h5py
 import numpy as np
 
 from .... import types
+from ... import settings
 from ...exceptions import LH5EncodeError
 
 log = logging.getLogger(__name__)
-
-DEFAULT_HDF5_SETTINGS: dict[str, ...] = {"shuffle": True, "compression": "gzip"}
 
 
 def _h5_write_array(
@@ -49,7 +48,7 @@ def _h5_write_array(
             del group[name]
 
         # set default compression options
-        for k, v in DEFAULT_HDF5_SETTINGS.items():
+        for k, v in settings.DEFAULT_HDF5_SETTINGS.items():
             h5py_kwargs.setdefault(k, v)
 
         # compress using the 'compression' LGDO attribute, if available

--- a/src/lgdo/lh5/settings.py
+++ b/src/lgdo/lh5/settings.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def default_hdf5_settings() -> dict[str, Any]:
+    """Returns the HDF5 settings for writing data to disk to the pydataobj defaults.
+
+    Examples
+    --------
+    >>> from lgdo import lh5
+    >>> lh5.DEFAULT_HDF5_SETTINGS["compression"] = "lzf"
+    >>> lh5.write(data, "data", "file.lh5")  # compressed with LZF
+    >>> lh5.DEFAULT_HDF5_SETTINGS = lh5.default_hdf5_settings()
+    >>> lh5.write(data, "data", "file.lh5", "of")  # compressed with default settings (GZIP)
+    """
+
+    return {
+        "shuffle": True,
+        "compression": "gzip",
+    }
+
+
+DEFAULT_HDF5_SETTINGS: dict[str, ...] = default_hdf5_settings()
+"""Global dictionary storing the default HDF5 settings for writing data to disk.
+
+Modify this global variable before writing data to disk with this package.
+
+Examples
+--------
+>>> from lgdo import lh5
+>>> lh5.DEFAULT_HDF5_SETTINGS["compression"] = "lzf"
+>>> lh5.write(data, "data", "file.lh5")  # compressed with LZF
+"""

--- a/tests/lh5/test_lh5_store.py
+++ b/tests/lh5/test_lh5_store.py
@@ -9,7 +9,6 @@ import pytest
 
 import lgdo
 from lgdo import lh5, types
-from lgdo.lh5 import DEFAULT_HDF5_SETTINGS
 
 
 def test_init():
@@ -96,7 +95,7 @@ def test_read_array(lh5_file):
     with h5py.File(lh5_file) as h5f:
         assert (
             h5f["/data/struct/array"].compression
-            is DEFAULT_HDF5_SETTINGS["compression"]
+            is lh5.settings.DEFAULT_HDF5_SETTINGS["compression"]
         )
 
     lh5_obj = store.read("/data/struct_full/array2d", lh5_file)
@@ -170,11 +169,11 @@ def test_read_vov(lh5_file):
     with h5py.File(lh5_file) as h5f:
         assert (
             h5f["/data/struct/vov/cumulative_length"].compression
-            is DEFAULT_HDF5_SETTINGS["compression"]
+            is lh5.settings.DEFAULT_HDF5_SETTINGS["compression"]
         )
         assert (
             h5f["/data/struct/vov/flattened_data"].compression
-            is DEFAULT_HDF5_SETTINGS["compression"]
+            is lh5.settings.DEFAULT_HDF5_SETTINGS["compression"]
         )
 
     lh5_obj = store.read("/data/struct/vov3d", lh5_file)
@@ -229,11 +228,11 @@ def test_read_voev(lh5_file):
         assert h5f["/data/struct/voev/encoded_data/flattened_data"].compression is None
         assert (
             h5f["/data/struct/voev/encoded_data/cumulative_length"].compression
-            is DEFAULT_HDF5_SETTINGS["compression"]
+            is lh5.settings.DEFAULT_HDF5_SETTINGS["compression"]
         )
         assert (
             h5f["/data/struct/voev/decoded_size"].compression
-            is DEFAULT_HDF5_SETTINGS["compression"]
+            is lh5.settings.DEFAULT_HDF5_SETTINGS["compression"]
         )
 
 
@@ -312,7 +311,7 @@ def test_read_hdf5_compressed_data(lh5_file):
     with h5py.File(lh5_file) as h5f:
         assert (
             h5f["/data/struct/table/a"].compression
-            is DEFAULT_HDF5_SETTINGS["compression"]
+            is lh5.settings.DEFAULT_HDF5_SETTINGS["compression"]
         )
         assert h5f["/data/struct/table/b"].compression == "gzip"
         assert h5f["/data/struct/table/c"].compression == "gzip"
@@ -333,15 +332,15 @@ def test_read_wftable(lh5_file):
     with h5py.File(lh5_file) as h5f:
         assert (
             h5f["/data/struct/wftable/values"].compression
-            is DEFAULT_HDF5_SETTINGS["compression"]
+            is lh5.settings.DEFAULT_HDF5_SETTINGS["compression"]
         )
         assert (
             h5f["/data/struct/wftable/t0"].compression
-            is DEFAULT_HDF5_SETTINGS["compression"]
+            is lh5.settings.DEFAULT_HDF5_SETTINGS["compression"]
         )
         assert (
             h5f["/data/struct/wftable/dt"].compression
-            is DEFAULT_HDF5_SETTINGS["compression"]
+            is lh5.settings.DEFAULT_HDF5_SETTINGS["compression"]
         )
 
 
@@ -387,11 +386,11 @@ def test_read_wftable_encoded(lh5_file):
         assert h5f["/data/struct/wftable_enc/values/decoded_size"].compression is None
         assert (
             h5f["/data/struct/wftable_enc/t0"].compression
-            is DEFAULT_HDF5_SETTINGS["compression"]
+            is lh5.settings.DEFAULT_HDF5_SETTINGS["compression"]
         )
         assert (
             h5f["/data/struct/wftable_enc/dt"].compression
-            is DEFAULT_HDF5_SETTINGS["compression"]
+            is lh5.settings.DEFAULT_HDF5_SETTINGS["compression"]
         )
 
 

--- a/tests/lh5/test_lh5_write.py
+++ b/tests/lh5/test_lh5_write.py
@@ -15,6 +15,30 @@ def test_write_compressed_lgnd_waveform_table(enc_lgnd_file):
     pass
 
 
+def test_write_with_hdf5_compression_global(tmptestdir):
+    data = types.Table(
+        size=1000,
+        col_dict={
+            "col1": types.Array(np.arange(0, 100, 0.1)),
+            "col2": types.Array(np.random.default_rng().random(1000)),
+        },
+    )
+    outfile = f"{tmptestdir}/write_hdf5_data_global_var.lh5"
+
+    lh5.settings.DEFAULT_HDF5_SETTINGS["shuffle"] = False
+    lh5.settings.DEFAULT_HDF5_SETTINGS["compression"] = "lzf"
+
+    lh5.write(data, "data", outfile, wo_mode="of")
+
+    with h5py.File(outfile) as h5f:
+        assert h5f["/data/col1"].shuffle is False
+        assert h5f["/data/col1"].compression == "lzf"
+
+    lh5.settings.DEFAULT_HDF5_SETTINGS = lh5.settings.default_hdf5_settings()
+    assert lh5.settings.DEFAULT_HDF5_SETTINGS["shuffle"] is True
+    assert lh5.settings.DEFAULT_HDF5_SETTINGS["compression"] == "gzip"
+
+
 def test_write_with_hdf5_compression(lgnd_file, tmptestdir):
     store = lh5.LH5Store()
     wft = store.read("/geds/raw/waveform", lgnd_file)


### PR DESCRIPTION
after moving code to `lh5._serializers`, user modification of global HDF5 settings broke.

- now users need to modify `lh5.settings.DEFAULT_HDF5_SETTINGS`
- add function to restore original default settings
- update tutorial
- add docstrings

CC @tdixon97 