### PR TITLE
Use asteval for Table.eval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+    "asteval",
     "awkward>=2",
     "awkward-pandas",
     "colorlog",

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -349,7 +349,7 @@ class Table(Struct, LGDOCollection):
             )
             out = evaluate(expr, raise_errors=True)
         elif library == "lgdo":
-            tb = {k: v for k, v in self.items()}
+            tb = dict(self)
             evaluate = Interpreter(
                 user_symbols=tb
                 | parameters

--- a/tests/types/test_table_eval.py
+++ b/tests/types/test_table_eval.py
@@ -42,7 +42,7 @@ def test_eval_dependency():
     assert isinstance(r, lgdo.Array)
     assert np.array_equal(r.nda, obj.a.nda + obj.b.nda)
 
-    r = obj.eval("a + tbl__z")
+    r = obj.eval("a + tbl__z", library="numexpr")
     assert isinstance(r, lgdo.Array)
     assert np.array_equal(r.nda, obj.a.nda + obj.tbl.z.nda)
 
@@ -82,23 +82,20 @@ def test_eval_dependency():
 
     assert obj.eval("np.sum(a) + ak.sum(e)")
 
-    # test with modules argument, the simplest is using directly lgdo
-    res = obj.eval("lgdo.Array([1,2,3])", {}, modules={"lgdo": lgdo})
+    # test with lgdo library
+    res = obj.eval("lgdo.Array([1,2,3])", library="lgdo")
     assert res == lgdo.Array([1, 2, 3])
-
-    # test with module returning np.array
-    assert obj.eval("np.sum(a)", {}, modules={"np": np}).value == np.int64(10)
 
     # check bad type
     with pytest.raises(RuntimeError):
-        obj.eval("hist.Hist()", modules={"hist": hist})
+        obj.eval("hist.Hist()", parameters={"hist": hist})
 
     # check impossible numexpr can still run
     assert np.allclose(
         obj.eval(
-            "a*args.value",
-            {"args": dbetto.AttrsDict({"value": 2})},
-            modules={"lgdo": lgdo},
+            "a.nda*args.value",
+            parameters={"args": dbetto.AttrsDict({"value": 2})},
+            library="lgdo",
         ).view_as("np"),
         [2, 4, 6, 8],
     )


### PR DESCRIPTION
This is an attempt to address https://github.com/legend-exp/legend-pydataobj/issues/135 using the [asteval](https://lmfit.github.io/asteval/index.html) package, which is [safer](https://lmfit.github.io/asteval/motivation.html) than the built in `eval`. This disables certain features of the language using essentially a white list ([see here](https://lmfit.github.io/asteval/api.html#configuring-which-features-the-interpreter-recognizes)).

The way this is not written is for `Table.eval` to take an extra argument `library` (similar to `view_as`). The table will then be `view_as`ed appropriately for this library, and the fields will be fed into the interpreter. In addition, modules needed for using that library are fed in (e.g., `ak` if library is `"ak"`).

I also added an argument `as_lgdo` to control the return type, so you can return as the `library` you provide or as an `LGDO` object (defaults to `True` since this is the current behavior).

I left in the `parameters` argument to feed in external values, but removed the `modules` argument; the user actually can still feed modules as `parameters`, but I'm not so sure we want that (at some point `Table.eval` isn't the right tool for the job...).

The libraries included here are (note `numpy` is automatically included):
- `lgdo`: includes the Table as LGDO objects and includes `lgdo.types` module
- `pd`: calls `pandas.DataFrame.eval`
- `numexpr`: similar to before; uses `flatten` to use `__` for nested objects, and then includes the `nda`s for each field (excluding `VectorOfVectors` fields)
- `ak`: includes fields as `ak` objects, and includes the `ak` module
- `np`: will throw an Error because `view_as('np')` is not implemented

Implementing each of these was extremely simple with `asteval`, and extending this system further would be fairly trivial!

Right now, this PR is not ready to merge; I have submitted it for the sake of discussion. In particular, this adds a new dependency in `asteval`, and it works a little differently from the old implementation. It should be possible to make the default behavior for no provided library act like before (basically `ak` if needed and `numexpr` otherwise). In addition, I have to still make sure the tests are appropriate.