### PR TITLE
Reduce import time with lazy compression

### DIFF
--- a/src/lgdo/compression/__init__.py
+++ b/src/lgdo/compression/__init__.py
@@ -24,10 +24,10 @@ interface for encoding/decoding :class:`~.lgdo.LGDO`\ s.
 
 from __future__ import annotations
 
+from importlib import import_module
+
 from .base import WaveformCodec
 from .generic import decode, encode
-from .radware import RadwareSigcompress
-from .varlen import ULEB128ZigZagDiff
 
 __all__ = [
     "RadwareSigcompress",
@@ -36,3 +36,13 @@ __all__ = [
     "decode",
     "encode",
 ]
+
+
+def __getattr__(name):
+    if name == "RadwareSigcompress":
+        return import_module(".radware", __name__).RadwareSigcompress
+    if name == "ULEB128ZigZagDiff":
+        return import_module(".varlen", __name__).ULEB128ZigZagDiff
+    module_name = __name__
+    msg = "module {!r} has no attribute {!r}".format(module_name, name)  # noqa: UP032
+    raise AttributeError(msg)

--- a/src/lgdo/compression/generic.py
+++ b/src/lgdo/compression/generic.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 
 from .. import types as lgdo
-from . import radware, varlen
 from .base import WaveformCodec
 
 log = logging.getLogger(__name__)
@@ -24,6 +23,8 @@ def encode(
     codec
         algorithm to be used for encoding.
     """
+    from . import radware, varlen
+
     log.debug(f"encoding {obj!r} with {codec}")
 
     if _is_codec(codec, radware.RadwareSigcompress):
@@ -64,6 +65,8 @@ def decode(
         raise RuntimeError(msg)
 
     codec = obj.attrs["codec"]
+    from . import radware, varlen
+
     log.debug(f"decoding {obj!r} with {codec}")
 
     if _is_codec(codec, radware.RadwareSigcompress):


### PR DESCRIPTION
## Summary
- optimize import performance by lazy-loading compression modules
- avoid loading Numba-heavy modules until used

## Testing
- `pre-commit run --files src/lgdo/compression/__init__.py src/lgdo/compression/generic.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684739ed763c83309052621619a9fd21