### PR TITLE
Enable postponed type evaluation in lh5 serializers

### DIFF
--- a/src/lgdo/lgdo_utils.py
+++ b/src/lgdo/lgdo_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from warnings import warn
 
 import numpy as np
@@ -29,7 +30,7 @@ def get_element_type(obj: object) -> str:
     return utils.get_element_type(obj)
 
 
-def parse_datatype(datatype: str) -> tuple[str, tuple[int, ...], str | list[str]]:
+def parse_datatype(datatype: str) -> tuple[str, tuple[int, ...], str | Sequence[str]]:
     warn(
         "'lgdo.lgdo_utils' has been renamed to 'lgdo.utils'. "
         "Please replace either 'import lgdo.lgdo_utils as utils' with 'import lgdo.utils as utils' "

--- a/src/lgdo/lh5/_serializers/read/__init__.py
+++ b/src/lgdo/lh5/_serializers/read/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/lgdo/lh5/_serializers/read/utils.py
+++ b/src/lgdo/lh5/_serializers/read/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Collection, Mapping
+from collections.abc import Collection, Mapping, Sequence
 
 import h5py
 import numpy as np
@@ -42,8 +42,8 @@ def build_field_mask(field_mask: Mapping[str, bool] | Collection[str]) -> defaul
 
 
 def eval_field_mask(
-    field_mask: defaultdict, all_fields: list[str]
-) -> list[tuple(str, defaultdict)]:
+    field_mask: defaultdict, all_fields: Sequence[str]
+) -> list[tuple[str, defaultdict]]:
     """Get list of fields that need to be loaded along with a sub-field-mask
     in case we have a nested Table"""
 

--- a/src/lgdo/lh5/_serializers/write/__init__.py
+++ b/src/lgdo/lh5/_serializers/write/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/lgdo/lh5/concat.py
+++ b/src/lgdo/lh5/concat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+from collections.abc import Sequence
 
 from lgdo.lh5 import LH5Iterator
 
@@ -11,7 +12,9 @@ log = logging.getLogger(__name__)
 
 
 def _get_obj_list(
-    lh5_files: list, include_list: list | None = None, exclude_list: list | None = None
+    lh5_files: Sequence[str],
+    include_list: Sequence[str] | None = None,
+    exclude_list: Sequence[str] | None = None,
 ) -> list[str]:
     """Extract a list of lh5 objects to concatenate.
 
@@ -140,12 +143,12 @@ def _remove_nested_fields(lgdos: dict, obj_list: list):
 
 
 def lh5concat(
-    lh5_files: list,
+    lh5_files: Sequence[str],
     output: str,
     overwrite: bool = False,
     *,
-    include_list: list | None = None,
-    exclude_list: list | None = None,
+    include_list: Sequence[str] | None = None,
+    exclude_list: Sequence[str] | None = None,
 ) -> None:
     """Concatenate LGDO Arrays, VectorOfVectors and Tables in LH5 files.
 

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-import typing
+from collections.abc import Iterator, Mapping, Sequence
 from warnings import warn
 
 import numpy as np
@@ -13,10 +13,10 @@ from ..units import default_units_registry as ureg
 from .store import LH5Store
 from .utils import expand_path
 
-LGDO = typing.Union[Array, Scalar, Struct, VectorOfVectors]
+LGDO = Array | Scalar | Struct | VectorOfVectors
 
 
-class LH5Iterator(typing.Iterator):
+class LH5Iterator(Iterator[LGDO]):
     """
     A class for iterating through one or more LH5 files, one block of entries
     at a time. This also accepts an entry list/mask to enable event selection,
@@ -63,18 +63,18 @@ class LH5Iterator(typing.Iterator):
 
     def __init__(
         self,
-        lh5_files: str | list[str],
-        groups: str | list[str] | list[list[str]],
+        lh5_files: str | Sequence[str],
+        groups: str | Sequence[str] | Sequence[Sequence[str]],
         base_path: str = "",
-        entry_list: list[int] | list[list[int]] | None = None,
-        entry_mask: list[bool] | list[list[bool]] | None = None,
+        entry_list: Sequence[int] | Sequence[Sequence[int]] | None = None,
+        entry_mask: Sequence[bool] | Sequence[Sequence[bool]] | None = None,
         i_start: int = 0,
         n_entries: int | None = None,
-        field_mask: dict[str, bool] | list[str] | tuple[str] | None = None,
+        field_mask: Mapping[str, bool] | Sequence[str] | None = None,
         buffer_len: int = "100*MB",
         file_cache: int = 10,
         file_map: NDArray[int] = None,
-        friend: typing.Iterator | None = None,
+        friend: Iterator | None = None,
     ) -> None:
         """
         Parameters
@@ -229,7 +229,7 @@ class LH5Iterator(typing.Iterator):
 
         # Attach the friend
         if friend is not None:
-            if not isinstance(friend, typing.Iterator):
+            if not isinstance(friend, Iterator):
                 msg = "Friend must be an Iterator"
                 raise ValueError(msg)
 
@@ -498,7 +498,7 @@ class LH5Iterator(typing.Iterator):
             else 0
         )
 
-    def __iter__(self) -> typing.Iterator:
+    def __iter__(self) -> Iterator[LGDO]:
         """Loop through entries in blocks of size buffer_len."""
         self.current_i_entry = 0
         self.next_i_entry = self.i_start

--- a/src/lgdo/types/array.py
+++ b/src/lgdo/types/array.py
@@ -190,7 +190,7 @@ class Array(LGDOCollection):
 
         return False
 
-    def __iter__(self) -> Iterator:
+    def __iter__(self) -> Iterator[np.generic]:
         yield from self.nda
 
     def __str__(self) -> str:

--- a/src/lgdo/types/arrayofequalsizedarrays.py
+++ b/src/lgdo/types/arrayofequalsizedarrays.py
@@ -95,8 +95,8 @@ class ArrayOfEqualSizedArrays(Array):
     def __len__(self) -> int:
         return len(self.nda)
 
-    def __iter__(self) -> Iterator[np.array]:
-        return self.nda.__iter__()
+    def __iter__(self) -> Iterator[np.ndarray]:
+        return iter(self.nda)
 
     def __next__(self) -> np.ndarray:
         return self.nda.__next__()

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -6,7 +6,7 @@ equal length and corresponding utilities.
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from types import ModuleType
 from typing import Any
 from warnings import warn
@@ -102,7 +102,7 @@ class Table(Struct, LGDOCollection):
         """Provides ``__len__`` for this array-like class."""
         return self.size
 
-    def reserve_capacity(self, capacity: int | list) -> None:
+    def reserve_capacity(self, capacity: int | Sequence[int]) -> None:
         "Set size (number of rows) of internal memory buffer"
         if isinstance(capacity, int):
             for obj in self.values():
@@ -115,11 +115,11 @@ class Table(Struct, LGDOCollection):
             for obj, cap in zip(self.values(), capacity):
                 obj.reserve_capacity(cap)
 
-    def get_capacity(self) -> int:
+    def get_capacity(self) -> list[int]:
         "Get list of capacities for each key"
         return [v.get_capacity() for v in self.values()]
 
-    def trim_capacity(self) -> int:
+    def trim_capacity(self) -> None:
         "Set capacity to be minimum needed to support Array size"
         for v in self.values():
             v.trim_capacity()
@@ -199,7 +199,10 @@ class Table(Struct, LGDOCollection):
         super().remove_field(name, delete)
 
     def join(
-        self, other_table: Table, cols: list[str] | None = None, do_warn: bool = True
+        self,
+        other_table: Table,
+        cols: Sequence[str] | None = None,
+        do_warn: bool = True,
     ) -> None:
         """Add the columns of another table to this table.
 
@@ -232,7 +235,7 @@ class Table(Struct, LGDOCollection):
 
     def get_dataframe(
         self,
-        cols: list[str] | None = None,
+        cols: Sequence[str] | None = None,
         copy: bool = False,  # noqa: ARG002
         prefix: str = "",
     ) -> pd.DataFrame:
@@ -465,7 +468,7 @@ class Table(Struct, LGDOCollection):
         self,
         library: str,
         with_units: bool = False,
-        cols: list[str] | None = None,
+        cols: Sequence[str] | None = None,
         prefix: str = "",
     ) -> pd.DataFrame | np.NDArray | ak.Array:
         r"""View the Table data as a third-party format data structure.

--- a/src/lgdo/types/vovutils.py
+++ b/src/lgdo/types/vovutils.py
@@ -252,7 +252,7 @@ def explode_arrays(
     cumulative_length: Array,
     arrays: Sequence[NDArray],
     arrays_out: Sequence[NDArray] | None = None,
-) -> list:
+) -> list[np.ndarray]:
     """Explode a set of arrays using a `cumulative_length` array.
 
     Parameters

--- a/src/lgdo/types/waveformtable.py
+++ b/src/lgdo/types/waveformtable.py
@@ -7,6 +7,7 @@ data.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 import awkward as ak
@@ -268,7 +269,7 @@ class WaveformTable(Table):
         self,
         library: str,
         with_units: bool = False,
-        cols: list[str] | None = None,
+        cols: Sequence[str] | None = None,
         prefix: str = "",
     ) -> pd.DataFrame | np.NDArray | ak.Array:
         r"""View the waveform data as a third-party format data structure.

--- a/src/lgdo/utils.py
+++ b/src/lgdo/utils.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Iterator, MutableMapping
-from typing import Any
 
 import numpy as np
 
@@ -105,23 +104,23 @@ class NumbaDefaults(MutableMapping):
         self.cache: bool = getenv_bool("LGDO_CACHE", default=True)
         self.boundscheck: bool = getenv_bool("LGDO_BOUNDSCHECK", default=False)
 
-    def __getitem__(self, item: str) -> Any:
+    def __getitem__(self, item: str) -> bool:
         return self.__dict__[item]
 
-    def __setitem__(self, item: str, val: Any) -> None:
+    def __setitem__(self, item: str, val: bool) -> None:
         self.__dict__[item] = val
 
     def __delitem__(self, item: str) -> None:
         del self.__dict__[item]
 
-    def __iter__(self) -> Iterator:
-        return self.__dict__.__iter__()
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.__dict__)
 
     def __len__(self) -> int:
         return len(self.__dict__)
 
-    def __call__(self, **kwargs) -> dict:
-        mapping = self.__dict__.copy()
+    def __call__(self, **kwargs) -> dict[str, bool]:
+        mapping: dict[str, bool] = self.__dict__.copy()
         mapping.update(**kwargs)
         return mapping
 


### PR DESCRIPTION
## Summary
- use postponed annotations for lh5 serializers
- refine iterator typing to follow modern conventions
- use Sequence types for list-based parameters
- refine type hints across package

## Testing
- `pre-commit run --files src/lgdo/types/table.py src/lgdo/lh5/_serializers/read/utils.py src/lgdo/lgdo_utils.py src/lgdo/types/vovutils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be3e6115483309bc51f84dfb55e60