### PR TITLE
Support pathlib.Path input

### DIFF
--- a/src/lgdo/lh5/core.py
+++ b/src/lgdo/lh5/core.py
@@ -19,7 +19,7 @@ from .utils import read_n_rows
 
 def read(
     name: str,
-    lh5_file: str | h5py.File | Sequence[str | h5py.File],
+    lh5_file: str | Path | h5py.File | Sequence[str | Path | h5py.File],
     start_row: int = 0,
     n_rows: int = sys.maxsize,
     idx: ArrayLike = None,
@@ -112,8 +112,8 @@ def read(
     """
     if isinstance(lh5_file, h5py.File):
         lh5_obj = lh5_file[name]
-    elif isinstance(lh5_file, str):
-        lh5_file = h5py.File(lh5_file, mode="r", locking=locking)
+    elif isinstance(lh5_file, (str, Path)):
+        lh5_file = h5py.File(str(Path(lh5_file)), mode="r", locking=locking)
         try:
             lh5_obj = lh5_file[name]
         except KeyError as ke:
@@ -195,7 +195,7 @@ def read(
 def write(
     obj: types.LGDO,
     name: str,
-    lh5_file: str | h5py.File,
+    lh5_file: str | Path | h5py.File,
     group: str | h5py.Group = "/",
     start_row: int = 0,
     n_rows: int | None = None,
@@ -318,7 +318,7 @@ def write(
 
 def read_as(
     name: str,
-    lh5_file: str | h5py.File | Sequence[str | h5py.File],
+    lh5_file: str | Path | h5py.File | Sequence[str | Path | h5py.File],
     library: str,
     **kwargs,
 ) -> Any:

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -38,7 +38,10 @@ class LH5Store:
     """
 
     def __init__(
-        self, base_path: str = "", keep_open: bool = False, locking: bool = False
+        self,
+        base_path: str | Path = "",
+        keep_open: bool = False,
+        locking: bool = False,
     ) -> None:
         """
         Parameters
@@ -52,6 +55,7 @@ class LH5Store:
         locking
             whether to lock files when reading
         """
+        base_path = str(Path(base_path)) if base_path != "" else ""
         self.base_path = "" if base_path == "" else utils.expand_path(base_path)
         self.keep_open = keep_open
         self.locking = locking
@@ -59,7 +63,7 @@ class LH5Store:
 
     def gimme_file(
         self,
-        lh5_file: str | h5py.File,
+        lh5_file: str | Path | h5py.File,
         mode: str = "r",
         page_buffer: int = 0,
         **file_kwargs,
@@ -82,6 +86,8 @@ class LH5Store:
         """
         if isinstance(lh5_file, h5py.File):
             return lh5_file
+
+        lh5_file = str(Path(lh5_file))
 
         if mode == "r":
             lh5_file = utils.expand_path(lh5_file, base_path=self.base_path)
@@ -147,7 +153,7 @@ class LH5Store:
     def get_buffer(
         self,
         name: str,
-        lh5_file: str | h5py.File | Sequence[str | h5py.File],
+        lh5_file: str | Path | h5py.File | Sequence[str | Path | h5py.File],
         size: int | None = None,
         field_mask: Mapping[str, bool] | Sequence[str] | None = None,
     ) -> types.LGDO:
@@ -162,7 +168,7 @@ class LH5Store:
     def read(
         self,
         name: str,
-        lh5_file: str | h5py.File | Sequence[str | h5py.File],
+        lh5_file: str | Path | h5py.File | Sequence[str | Path | h5py.File],
         start_row: int = 0,
         n_rows: int = sys.maxsize,
         idx: ArrayLike = None,
@@ -180,7 +186,7 @@ class LH5Store:
         .lh5.core.read
         """
         # grab files from store
-        if isinstance(lh5_file, (str, h5py.File)):
+        if isinstance(lh5_file, (str, Path, h5py.File)):
             h5f = self.gimme_file(lh5_file, "r", **file_kwargs)
         else:
             h5f = [self.gimme_file(f, "r", **file_kwargs) for f in lh5_file]
@@ -201,7 +207,7 @@ class LH5Store:
         self,
         obj: types.LGDO,
         name: str,
-        lh5_file: str | h5py.File,
+        lh5_file: str | Path | h5py.File,
         group: str | h5py.Group = "/",
         start_row: int = 0,
         n_rows: int | None = None,
@@ -256,14 +262,14 @@ class LH5Store:
             **h5py_kwargs,
         )
 
-    def read_n_rows(self, name: str, lh5_file: str | h5py.File) -> int | None:
+    def read_n_rows(self, name: str, lh5_file: str | Path | h5py.File) -> int | None:
         """Look up the number of rows in an Array-like object called `name` in `lh5_file`.
 
         Return ``None`` if it is a :class:`.Scalar` or a :class:`.Struct`.
         """
         return utils.read_n_rows(name, self.gimme_file(lh5_file, "r"))
 
-    def read_size_in_bytes(self, name: str, lh5_file: str | h5py.File) -> int:
+    def read_size_in_bytes(self, name: str, lh5_file: str | Path | h5py.File) -> int:
         """Look up the size (in B) of the object in memory. Will recursively
         crawl through all objects in a Struct or Table
         """

--- a/src/lgdo/lh5/tools.py
+++ b/src/lgdo/lh5/tools.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import fnmatch
 import logging
 from copy import copy
+from pathlib import Path
 
 import h5py
 
@@ -13,7 +14,7 @@ log = logging.getLogger(__name__)
 
 
 def ls(
-    lh5_file: str | h5py.Group,
+    lh5_file: str | Path | h5py.Group,
     lh5_group: str = "",
     recursive: bool = False,
 ) -> list[str]:
@@ -39,8 +40,8 @@ def ls(
 
     lh5_st = LH5Store()
     # To use recursively, make lh5_file a h5group instead of a string
-    if isinstance(lh5_file, str):
-        lh5_file = lh5_st.gimme_file(lh5_file, "r")
+    if isinstance(lh5_file, (str, Path)):
+        lh5_file = lh5_st.gimme_file(str(Path(lh5_file)), "r")
         if lh5_group.startswith("/"):
             lh5_group = lh5_group[1:]
 
@@ -75,7 +76,7 @@ def ls(
 
 
 def show(
-    lh5_file: str | h5py.Group,
+    lh5_file: str | Path | h5py.Group,
     lh5_group: str = "/",
     attrs: bool = False,
     indent: str = "",
@@ -121,8 +122,8 @@ def show(
         return
 
     # open file
-    if isinstance(lh5_file, str):
-        lh5_file = h5py.File(utils.expand_path(lh5_file), "r", locking=False)
+    if isinstance(lh5_file, (str, Path)):
+        lh5_file = h5py.File(utils.expand_path(Path(lh5_file)), "r", locking=False)
 
     # go to group
     if lh5_group != "/":

--- a/tests/lh5/test_pathlib.py
+++ b/tests/lh5/test_pathlib.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from lgdo import lh5, types
+from lgdo.lh5 import utils
+
+
+def test_expand_path_with_path_objects(tmp_path):
+    f = tmp_path / "file.lh5"
+    f.touch()
+    # direct Path
+    assert utils.expand_path(f) == str(f)
+    # Path with base_path as Path
+    assert utils.expand_path(f.name, base_path=tmp_path) == f.name
+    assert utils.expand_path(Path(f.name), base_path=Path(tmp_path)) == f.name
+    # wildcard with Path
+    assert utils.expand_path(tmp_path / "*.lh5", list=True) == [str(f)]
+
+
+def test_read_write_with_path_objects(tmp_path):
+    arr = types.Array(np.arange(5))
+    out = tmp_path / "out.lh5"
+    lh5.write(arr, "arr", out, group="/data", wo_mode="overwrite_file")
+    result = lh5.read("/data/arr", out)
+    assert np.array_equal(result.nda, np.arange(5))
+
+
+def test_store_with_path_objects(lh5_file, tmp_path):
+    store = lh5.LH5Store(base_path=tmp_path)
+    path_obj = Path(lh5_file)
+    obj = store.read("/data/struct/scalar", path_obj)
+    assert obj.value == 10
+    out = tmp_path / "out_store.lh5"
+    arr = types.Array(np.arange(3))
+    store.write(arr, "arr", out, group="/data", wo_mode="overwrite_file")
+    obj2 = store.read("/data/arr", out)
+    assert np.array_equal(obj2.nda, np.arange(3))


### PR DESCRIPTION
## Summary
- handle `pathlib.Path` arguments across LH5 helpers
- rely on `Path` rather than `os.fspath` and `os.PathLike`
- fix base path normalization to avoid converting empty paths to '.'
- ensure `expand_path` only prefixes relative paths

## Testing
- `pre-commit run --files src/lgdo/lh5/core.py src/lgdo/lh5/store.py src/lgdo/lh5/tools.py src/lgdo/lh5/utils.py tests/lh5/test_pathlib.py`
- `pytest -q`

Closes #166

------
https://chatgpt.com/codex/tasks/task_e_684bf92591708330bb50d44f12846b3b