### PR TITLE
Improve typing and packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ graft src
 graft tests
 
 include LICENSE README.md pyproject.toml setup.py setup.cfg
-global-exclude __pycache__ *.py[cod] .*
+global-exclude __pycache__ *.py[cod] .* *.nbc *.nbi

--- a/src/lgdo/lh5/_serializers/read/utils.py
+++ b/src/lgdo/lh5/_serializers/read/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Collection, Mapping
+from collections.abc import Collection, Mapping, Sequence
 
 import h5py
 import numpy as np
@@ -42,16 +42,18 @@ def build_field_mask(field_mask: Mapping[str, bool] | Collection[str]) -> defaul
 
 
 def eval_field_mask(
-    field_mask: defaultdict, all_fields: list[str]
-) -> list[tuple(str, defaultdict)]:
+    field_mask: Mapping[str, bool] | None,
+    all_fields: Sequence[str],
+) -> list[tuple[str, Mapping[str, bool] | None]]:
     """Get list of fields that need to be loaded along with a sub-field-mask
     in case we have a nested Table"""
 
     if field_mask is None:
-        return all_fields
+        return [(field, None) for field in all_fields]
 
-    this_field_mask = defaultdict(field_mask.default_factory)
-    sub_field_masks = {}
+    default = getattr(field_mask, "default_factory", lambda: False)
+    this_field_mask = defaultdict(default)
+    sub_field_masks: dict[str, Mapping[str, bool] | None] = {}
 
     for key, val in field_mask.items():
         field = key.strip("/")
@@ -62,9 +64,7 @@ def eval_field_mask(
             sub_field = field[pos + 1 :]
             field = field[:pos]
             this_field_mask[field] = True
-            sub_mask = sub_field_masks.setdefault(
-                field, defaultdict(field_mask.default_factory)
-            )
+            sub_mask = sub_field_masks.setdefault(field, defaultdict(default))
             sub_mask[sub_field] = val
 
     return [

--- a/src/lgdo/lh5/_serializers/read/utils.py
+++ b/src/lgdo/lh5/_serializers/read/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Collection, Mapping, Sequence
+from collections.abc import Collection, Mapping
 
 import h5py
 import numpy as np
@@ -43,7 +43,7 @@ def build_field_mask(field_mask: Mapping[str, bool] | Collection[str]) -> defaul
 
 def eval_field_mask(
     field_mask: Mapping[str, bool] | None,
-    all_fields: Sequence[str],
+    all_fields: Collection[str],
 ) -> list[tuple[str, Mapping[str, bool] | None]]:
     """Get list of fields that need to be loaded along with a sub-field-mask
     in case we have a nested Table"""

--- a/src/lgdo/lh5/concat.py
+++ b/src/lgdo/lh5/concat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+from collections.abc import Sequence
 
 from lgdo.lh5 import LH5Iterator
 
@@ -11,7 +12,9 @@ log = logging.getLogger(__name__)
 
 
 def _get_obj_list(
-    lh5_files: list, include_list: list | None = None, exclude_list: list | None = None
+    lh5_files: Sequence[str],
+    include_list: Sequence[str] | None = None,
+    exclude_list: Sequence[str] | None = None,
 ) -> list[str]:
     """Extract a list of lh5 objects to concatenate.
 
@@ -140,12 +143,12 @@ def _remove_nested_fields(lgdos: dict, obj_list: list):
 
 
 def lh5concat(
-    lh5_files: list,
+    lh5_files: Sequence[str],
     output: str,
     overwrite: bool = False,
     *,
-    include_list: list | None = None,
-    exclude_list: list | None = None,
+    include_list: Sequence[str] | None = None,
+    exclude_list: Sequence[str] | None = None,
 ) -> None:
     """Concatenate LGDO Arrays, VectorOfVectors and Tables in LH5 files.
 

--- a/src/lgdo/lh5/concat.py
+++ b/src/lgdo/lh5/concat.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import fnmatch
 import logging
-from collections.abc import Sequence
+from collections.abc import Collection
 
 from lgdo.lh5 import LH5Iterator
 
@@ -12,9 +12,9 @@ log = logging.getLogger(__name__)
 
 
 def _get_obj_list(
-    lh5_files: Sequence[str],
-    include_list: Sequence[str] | None = None,
-    exclude_list: Sequence[str] | None = None,
+    lh5_files: Collection[str],
+    include_list: Collection[str] | None = None,
+    exclude_list: Collection[str] | None = None,
 ) -> list[str]:
     """Extract a list of lh5 objects to concatenate.
 
@@ -28,7 +28,7 @@ def _get_obj_list(
         patterns for tables to exclude.
 
     """
-    file0 = lh5_files[0]
+    file0 = next(iter(lh5_files))
     obj_list_full = set(lh5.ls(file0, recursive=True))
 
     # let's remove objects with nested LGDOs inside
@@ -143,12 +143,12 @@ def _remove_nested_fields(lgdos: dict, obj_list: list):
 
 
 def lh5concat(
-    lh5_files: Sequence[str],
+    lh5_files: Collection[str],
     output: str,
     overwrite: bool = False,
     *,
-    include_list: Sequence[str] | None = None,
-    exclude_list: Sequence[str] | None = None,
+    include_list: Collection[str] | None = None,
+    exclude_list: Collection[str] | None = None,
 ) -> None:
     """Concatenate LGDO Arrays, VectorOfVectors and Tables in LH5 files.
 
@@ -173,10 +173,13 @@ def lh5concat(
         lh5_files, include_list=include_list, exclude_list=exclude_list
     )
 
-    msg = f"objects matching include patterns {include_list} in {lh5_files[0]}: {obj_list}"
+    first_file = next(iter(lh5_files))
+    msg = (
+        f"objects matching include patterns {include_list} in {first_file}: {obj_list}"
+    )
     log.info(msg)
 
-    lgdos, lgdo_structs = _get_lgdos(lh5_files[0], obj_list)
+    lgdos, lgdo_structs = _get_lgdos(first_file, obj_list)
     first_done = False
     store = lh5.LH5Store()
 

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import typing
+from collections.abc import Mapping, Sequence
 from warnings import warn
 
 import numpy as np
@@ -58,14 +59,14 @@ class LH5Iterator(typing.Iterator):
 
     def __init__(
         self,
-        lh5_files: str | list[str],
-        groups: str | list[str] | list[list[str]],
+        lh5_files: str | Sequence[str],
+        groups: str | Sequence[str] | Sequence[Sequence[str]],
         base_path: str = "",
-        entry_list: list[int] | list[list[int]] | None = None,
-        entry_mask: list[bool] | list[list[bool]] | None = None,
+        entry_list: Sequence[int] | Sequence[Sequence[int]] | None = None,
+        entry_mask: Sequence[bool] | Sequence[Sequence[bool]] | None = None,
         i_start: int = 0,
         n_entries: int | None = None,
-        field_mask: dict[str, bool] | list[str] | tuple[str] | None = None,
+        field_mask: Mapping[str, bool] | Sequence[str] | None = None,
         buffer_len: int = "100*MB",
         file_cache: int = 10,
         file_map: NDArray[int] = None,

--- a/src/lgdo/lh5/iterator.py
+++ b/src/lgdo/lh5/iterator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import typing
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from warnings import warn
 
 import numpy as np
@@ -62,11 +62,11 @@ class LH5Iterator(typing.Iterator):
         lh5_files: str | Sequence[str],
         groups: str | Sequence[str] | Sequence[Sequence[str]],
         base_path: str = "",
-        entry_list: Sequence[int] | Sequence[Sequence[int]] | None = None,
-        entry_mask: Sequence[bool] | Sequence[Sequence[bool]] | None = None,
+        entry_list: Collection[int] | Collection[Collection[int]] | None = None,
+        entry_mask: Collection[bool] | Collection[Collection[bool]] | None = None,
         i_start: int = 0,
         n_entries: int | None = None,
-        field_mask: Mapping[str, bool] | Sequence[str] | None = None,
+        field_mask: Mapping[str, bool] | Collection[str] | None = None,
         buffer_len: int = "100*MB",
         file_cache: int = 10,
         file_map: NDArray[int] = None,

--- a/src/lgdo/lh5/store.py
+++ b/src/lgdo/lh5/store.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import sys
 from collections import OrderedDict
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from inspect import signature
 from pathlib import Path
 from typing import Any
@@ -149,7 +149,7 @@ class LH5Store:
         name: str,
         lh5_file: str | h5py.File | Sequence[str | h5py.File],
         size: int | None = None,
-        field_mask: Mapping[str, bool] | Sequence[str] | None = None,
+        field_mask: Mapping[str, bool] | Collection[str] | None = None,
     ) -> types.LGDO:
         """Returns an LH5 object appropriate for use as a pre-allocated buffer
         in a read loop. Sets size to `size` if object has a size.
@@ -167,7 +167,7 @@ class LH5Store:
         n_rows: int = sys.maxsize,
         idx: ArrayLike = None,
         use_h5idx: bool = False,
-        field_mask: Mapping[str, bool] | Sequence[str] | None = None,
+        field_mask: Mapping[str, bool] | Collection[str] | None = None,
         obj_buf: types.LGDO = None,
         obj_buf_start: int = 0,
         decompress: bool = True,

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -6,7 +6,7 @@ import glob
 import logging
 import os
 import string
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -23,7 +23,7 @@ def get_buffer(
     name: str,
     lh5_file: str | h5py.File | Sequence[str | h5py.File],
     size: int | None = None,
-    field_mask: Mapping[str, bool] | Sequence[str] | None = None,
+    field_mask: Mapping[str, bool] | Collection[str] | None = None,
 ) -> types.LGDO:
     """Returns an LGDO appropriate for use as a pre-allocated buffer.
 

--- a/src/lgdo/lh5/utils.py
+++ b/src/lgdo/lh5/utils.py
@@ -132,7 +132,7 @@ def get_h5_group(
     return group
 
 
-def expand_vars(expr: str, substitute: dict[str, str] | None = None) -> str:
+def expand_vars(expr: str, substitute: Mapping[str, str] | None = None) -> str:
     """Expand (environment) variables.
 
     Note
@@ -159,10 +159,10 @@ def expand_vars(expr: str, substitute: dict[str, str] | None = None) -> str:
 
 def expand_path(
     path: str,
-    substitute: dict[str, str] | None = None,
+    substitute: Mapping[str, str] | None = None,
     list: bool = False,
     base_path: str | None = None,
-) -> str | list:
+) -> str | Sequence[str]:
     """Expand (environment) variables and wildcards to return absolute paths.
 
     Parameters

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -6,7 +6,7 @@ equal length and corresponding utilities.
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping
 from types import ModuleType
 from typing import Any
 from warnings import warn
@@ -201,7 +201,7 @@ class Table(Struct, LGDOCollection):
     def join(
         self,
         other_table: Table,
-        cols: Sequence[str] | None = None,
+        cols: Collection[str] | None = None,
         do_warn: bool = True,
     ) -> None:
         """Add the columns of another table to this table.
@@ -235,7 +235,7 @@ class Table(Struct, LGDOCollection):
 
     def get_dataframe(
         self,
-        cols: Sequence[str] | None = None,
+        cols: Collection[str] | None = None,
         copy: bool = False,  # noqa: ARG002
         prefix: str = "",
     ) -> pd.DataFrame:
@@ -468,7 +468,7 @@ class Table(Struct, LGDOCollection):
         self,
         library: str,
         with_units: bool = False,
-        cols: Sequence[str] | None = None,
+        cols: Collection[str] | None = None,
         prefix: str = "",
     ) -> pd.DataFrame | np.NDArray | ak.Array:
         r"""View the Table data as a third-party format data structure.

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -6,7 +6,7 @@ equal length and corresponding utilities.
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from types import ModuleType
 from typing import Any
 from warnings import warn
@@ -199,7 +199,10 @@ class Table(Struct, LGDOCollection):
         super().remove_field(name, delete)
 
     def join(
-        self, other_table: Table, cols: list[str] | None = None, do_warn: bool = True
+        self,
+        other_table: Table,
+        cols: Sequence[str] | None = None,
+        do_warn: bool = True,
     ) -> None:
         """Add the columns of another table to this table.
 
@@ -232,7 +235,7 @@ class Table(Struct, LGDOCollection):
 
     def get_dataframe(
         self,
-        cols: list[str] | None = None,
+        cols: Sequence[str] | None = None,
         copy: bool = False,  # noqa: ARG002
         prefix: str = "",
     ) -> pd.DataFrame:
@@ -465,7 +468,7 @@ class Table(Struct, LGDOCollection):
         self,
         library: str,
         with_units: bool = False,
-        cols: list[str] | None = None,
+        cols: Sequence[str] | None = None,
         prefix: str = "",
     ) -> pd.DataFrame | np.NDArray | ak.Array:
         r"""View the Table data as a third-party format data structure.

--- a/src/lgdo/types/waveformtable.py
+++ b/src/lgdo/types/waveformtable.py
@@ -7,7 +7,7 @@ data.
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Collection
 from typing import Any
 
 import awkward as ak
@@ -269,7 +269,7 @@ class WaveformTable(Table):
         self,
         library: str,
         with_units: bool = False,
-        cols: Sequence[str] | None = None,
+        cols: Collection[str] | None = None,
         prefix: str = "",
     ) -> pd.DataFrame | np.NDArray | ak.Array:
         r"""View the waveform data as a third-party format data structure.

--- a/src/lgdo/types/waveformtable.py
+++ b/src/lgdo/types/waveformtable.py
@@ -7,6 +7,7 @@ data.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 import awkward as ak
@@ -268,7 +269,7 @@ class WaveformTable(Table):
         self,
         library: str,
         with_units: bool = False,
-        cols: list[str] | None = None,
+        cols: Sequence[str] | None = None,
         prefix: str = "",
     ) -> pd.DataFrame | np.NDArray | ak.Array:
         r"""View the waveform data as a third-party format data structure.


### PR DESCRIPTION
## Summary
- broaden input type hints to use generic Sequence and Mapping
- exclude numba cache files from the wheel
- update helper annotations for field masks

## Testing
- `pre-commit run --files MANIFEST.in src/lgdo/lh5/concat.py src/lgdo/lh5/iterator.py src/lgdo/lh5/_serializers/read/utils.py src/lgdo/lh5/utils.py src/lgdo/types/table.py src/lgdo/types/waveformtable.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c22b12960833099916e4acb2c4668