### PR TITLE
Fix open file handles on serialization errors

### DIFF
--- a/src/lgdo/lh5/_serializers/write/composite.py
+++ b/src/lgdo/lh5/_serializers/write/composite.py
@@ -52,140 +52,129 @@ def _h5_write_lgdo(
     # In hdf5, 'a' is really "modify" -- in addition to appending, you can
     # change any object in the file. So we use file:append for
     # write_object:overwrite.
+    opened_here = False
     if not isinstance(lh5_file, h5py.File):
         mode = "w" if wo_mode == "of" or not Path(lh5_file).exists() else "a"
-        lh5_file = h5py.File(lh5_file, mode=mode, **file_kwargs)
 
-    log.debug(
-        f"writing {obj!r}[{start_row}:{n_rows}] as "
-        f"{lh5_file.filename}:{group}/{name}[{write_start}:], "
-        f"mode = {wo_mode}, h5py_kwargs = {h5py_kwargs}"
-    )
+        try:
+            fh = h5py.File(lh5_file, mode=mode, **file_kwargs)
+        except OSError as oe:
+            raise LH5EncodeError(str(oe), lh5_file, None) from oe
 
-    group = utils.get_h5_group(group, lh5_file)
-
-    # name already in file
-    if name in group or (
-        ("datatype" in group.attrs or group == "/")
-        and (len(name) <= 2 or "/" not in name[1:-1])
-    ):
-        pass
-    # group is in file but not struct or need to create nesting
+        opened_here = True
     else:
-        # check if name is nested
-        # if name is nested, iterate up from parent
-        # otherwise we just need to iterate the group
-        if len(name) > 2 and "/" in name[1:-1]:
-            group = utils.get_h5_group(
-                name[:-1].rsplit("/", 1)[0],
-                group,
-            )
-            curr_name = (
-                name.rsplit("/", 1)[1]
-                if name[-1] != "/"
-                else name[:-1].rsplit("/", 1)[1]
-            )
-        else:
-            curr_name = name
-        # initialize the object to be written
-        obj = types.Struct({curr_name.replace("/", ""): obj})
+        fh = lh5_file
 
-        # if base group already has a child we just append
-        if len(group) >= 1:
-            wo_mode = "ac"
-        else:
-            # iterate up the group hierarchy until we reach the root or a group with more than one child
-            while group.name != "/":
-                if len(group) > 1:
-                    break
-                curr_name = group.name
-                group = group.parent
-                if group.name != "/":
-                    obj = types.Struct({curr_name[len(group.name) + 1 :]: obj})
-                else:
-                    obj = types.Struct({curr_name[1:]: obj})
-            # if the group has more than one child, we need to append else we can overwrite
-            wo_mode = "ac" if len(group) > 1 else "o"
+    try:
+        log.debug(
+            f"writing {obj!r}[{start_row}:{n_rows}] as "
+            f"{fh.filename}:{group}/{name}[{write_start}:], "
+            f"mode = {wo_mode}, h5py_kwargs = {h5py_kwargs}"
+        )
 
-        # set the new name
-        if group.name == "/":
-            name = "/"
-        elif group.parent.name == "/":
-            name = group.name[1:]
-        else:
-            name = group.name[len(group.parent.name) + 1 :]
-        # get the new group
-        group = utils.get_h5_group(group.parent if group.name != "/" else "/", lh5_file)
+        group = utils.get_h5_group(group, fh)
 
-    if wo_mode == "w" and name in group:
-        msg = f"can't overwrite '{name}' in wo_mode 'write_safe'"
-        raise LH5EncodeError(msg, lh5_file, group, name)
-
-    # struct, table, waveform table or histogram.
-    if isinstance(obj, types.Struct):
-        if (
-            isinstance(obj, types.Histogram)
-            and wo_mode not in ["w", "o", "of"]
-            and name in group
+        # name already in file
+        if name in group or (
+            ("datatype" in group.attrs or group == "/")
+            and (len(name) <= 2 or "/" not in name[1:-1])
         ):
-            msg = f"can't append-write to histogram in wo_mode '{wo_mode}'"
-            raise LH5EncodeError(msg, lh5_file, group, name)
-        if isinstance(obj, types.Histogram) and write_start != 0:
-            msg = f"can't write histogram in wo_mode '{wo_mode}' with write_start != 0"
-            raise LH5EncodeError(msg, lh5_file, group, name)
-
-        return _h5_write_struct(
-            obj,
-            name,
-            lh5_file,
-            group=group,
-            start_row=start_row,
-            n_rows=n_rows,  # if isinstance(obj, types.Table | types.Histogram) else None,
-            wo_mode=wo_mode,
-            write_start=write_start,
-            **h5py_kwargs,
-        )
-
-    # scalars
-    if isinstance(obj, types.Scalar):
-        return _h5_write_scalar(obj, name, lh5_file, group, wo_mode)
-
-    # vector of encoded vectors
-    if isinstance(
-        obj, (types.VectorOfEncodedVectors, types.ArrayOfEncodedEqualSizedArrays)
-    ):
-        group = utils.get_h5_group(
-            name, group, grp_attrs=obj.attrs, overwrite=(wo_mode == "o")
-        )
-
-        # ask not to further compress flattened_data, it is already compressed!
-        obj.encoded_data.flattened_data.attrs["compression"] = None
-
-        _h5_write_vector_of_vectors(
-            obj.encoded_data,
-            "encoded_data",
-            lh5_file,
-            group=group,
-            start_row=start_row,
-            n_rows=n_rows,
-            wo_mode=wo_mode,
-            write_start=write_start,
-            **h5py_kwargs,
-        )
-
-        if isinstance(obj.decoded_size, types.Scalar):
-            _h5_write_scalar(
-                obj.decoded_size,
-                "decoded_size",
-                lh5_file,
-                group=group,
-                wo_mode=wo_mode,
-            )
+            pass
+        # group is in file but not struct or need to create nesting
         else:
-            _h5_write_array(
-                obj.decoded_size,
-                "decoded_size",
-                lh5_file,
+            # check if name is nested
+            # if name is nested, iterate up from parent
+            # otherwise we just need to iterate the group
+            if len(name) > 2 and "/" in name[1:-1]:
+                group = utils.get_h5_group(
+                    name[:-1].rsplit("/", 1)[0],
+                    group,
+                )
+                curr_name = (
+                    name.rsplit("/", 1)[1]
+                    if name[-1] != "/"
+                    else name[:-1].rsplit("/", 1)[1]
+                )
+            else:
+                curr_name = name
+            # initialize the object to be written
+            obj = types.Struct({curr_name.replace("/", ""): obj})
+
+            # if base group already has a child we just append
+            if len(group) >= 1:
+                wo_mode = "ac"
+            else:
+                # iterate up the group hierarchy until we reach the root or a group with more than one child
+                while group.name != "/":
+                    if len(group) > 1:
+                        break
+                    curr_name = group.name
+                    group = group.parent
+                    if group.name != "/":
+                        obj = types.Struct({curr_name[len(group.name) + 1 :]: obj})
+                    else:
+                        obj = types.Struct({curr_name[1:]: obj})
+                # if the group has more than one child, we need to append else we can overwrite
+                wo_mode = "ac" if len(group) > 1 else "o"
+
+            # set the new name
+            if group.name == "/":
+                name = "/"
+            elif group.parent.name == "/":
+                name = group.name[1:]
+            else:
+                name = group.name[len(group.parent.name) + 1 :]
+            # get the new group
+            group = utils.get_h5_group(group.parent if group.name != "/" else "/", fh)
+
+        if wo_mode == "w" and name in group:
+            msg = f"can't overwrite '{name}' in wo_mode 'write_safe'"
+            raise LH5EncodeError(msg, fh, group, name)
+
+        # struct, table, waveform table or histogram.
+        if isinstance(obj, types.Struct):
+            if (
+                isinstance(obj, types.Histogram)
+                and wo_mode not in ["w", "o", "of"]
+                and name in group
+            ):
+                msg = f"can't append-write to histogram in wo_mode '{wo_mode}'"
+                raise LH5EncodeError(msg, fh, group, name)
+            if isinstance(obj, types.Histogram) and write_start != 0:
+                msg = f"can't write histogram in wo_mode '{wo_mode}' with write_start != 0"
+                raise LH5EncodeError(msg, fh, group, name)
+
+            return _h5_write_struct(
+                obj,
+                name,
+                fh,
+                group=group,
+                start_row=start_row,
+                n_rows=n_rows,  # if isinstance(obj, types.Table | types.Histogram) else None,
+                wo_mode=wo_mode,
+                write_start=write_start,
+                **h5py_kwargs,
+            )
+
+        # scalars
+        if isinstance(obj, types.Scalar):
+            return _h5_write_scalar(obj, name, fh, group, wo_mode)
+
+        # vector of encoded vectors
+        if isinstance(
+            obj, (types.VectorOfEncodedVectors, types.ArrayOfEncodedEqualSizedArrays)
+        ):
+            group = utils.get_h5_group(
+                name, group, grp_attrs=obj.attrs, overwrite=(wo_mode == "o")
+            )
+
+            # ask not to further compress flattened_data, it is already compressed!
+            obj.encoded_data.flattened_data.attrs["compression"] = None
+
+            _h5_write_vector_of_vectors(
+                obj.encoded_data,
+                "encoded_data",
+                fh,
                 group=group,
                 start_row=start_row,
                 n_rows=n_rows,
@@ -194,38 +183,62 @@ def _h5_write_lgdo(
                 **h5py_kwargs,
             )
 
-        return None
+            if isinstance(obj.decoded_size, types.Scalar):
+                _h5_write_scalar(
+                    obj.decoded_size,
+                    "decoded_size",
+                    fh,
+                    group=group,
+                    wo_mode=wo_mode,
+                )
+            else:
+                _h5_write_array(
+                    obj.decoded_size,
+                    "decoded_size",
+                    fh,
+                    group=group,
+                    start_row=start_row,
+                    n_rows=n_rows,
+                    wo_mode=wo_mode,
+                    write_start=write_start,
+                    **h5py_kwargs,
+                )
 
-    # vector of vectors
-    if isinstance(obj, types.VectorOfVectors):
-        return _h5_write_vector_of_vectors(
-            obj,
-            name,
-            lh5_file,
-            group=group,
-            start_row=start_row,
-            n_rows=n_rows,
-            wo_mode=wo_mode,
-            write_start=write_start,
-            **h5py_kwargs,
-        )
+            return None
 
-    # if we get this far, must be one of the Array types
-    if isinstance(obj, types.Array):
-        return _h5_write_array(
-            obj,
-            name,
-            lh5_file,
-            group=group,
-            start_row=start_row,
-            n_rows=n_rows,
-            wo_mode=wo_mode,
-            write_start=write_start,
-            **h5py_kwargs,
-        )
+        # vector of vectors
+        if isinstance(obj, types.VectorOfVectors):
+            return _h5_write_vector_of_vectors(
+                obj,
+                name,
+                fh,
+                group=group,
+                start_row=start_row,
+                n_rows=n_rows,
+                wo_mode=wo_mode,
+                write_start=write_start,
+                **h5py_kwargs,
+            )
 
-    msg = f"do not know how to write '{name}' of type '{type(obj).__name__}'"
-    raise LH5EncodeError(msg, lh5_file, group, name)
+        # if we get this far, must be one of the Array types
+        if isinstance(obj, types.Array):
+            return _h5_write_array(
+                obj,
+                name,
+                fh,
+                group=group,
+                start_row=start_row,
+                n_rows=n_rows,
+                wo_mode=wo_mode,
+                write_start=write_start,
+                **h5py_kwargs,
+            )
+
+        msg = f"do not know how to write '{name}' of type '{type(obj).__name__}'"
+        raise LH5EncodeError(msg, fh, group, name)
+    finally:
+        if opened_here:
+            fh.close()
 
 
 def _h5_write_struct(

--- a/src/lgdo/lh5/exceptions.py
+++ b/src/lgdo/lh5/exceptions.py
@@ -4,17 +4,21 @@ import h5py
 
 
 class LH5DecodeError(Exception):
-    def __init__(self, message: str, fname: str, oname: str) -> None:
+    def __init__(
+        self, message: str, file: str | h5py.File, oname: str | None = None
+    ) -> None:
         super().__init__(message)
 
-        self.file = fname
+        self.file = file.filename if isinstance(file, h5py.File) else file
         self.obj = oname
 
     def __str__(self) -> str:
-        return (
-            f"while reading object '{self.obj}' in file {self.file}: "
-            + super().__str__()
-        )
+        if self.obj is None:
+            msg = f"while opening file {self.file} for decoding: "
+        else:
+            msg = f"while decoding object '{self.obj}' in file {self.file}: "
+
+        return msg + super().__str__()
 
     def __reduce__(self) -> tuple:  # for pickling.
         return self.__class__, (*self.args, self.file, self.obj)
@@ -22,19 +26,30 @@ class LH5DecodeError(Exception):
 
 class LH5EncodeError(Exception):
     def __init__(
-        self, message: str, file: str | h5py.File, group: str | h5py.Group, name: str
+        self,
+        message: str,
+        file: str | h5py.File,
+        group: str | h5py.Group | None = None,
+        name: str | None = None,
     ) -> None:
         super().__init__(message)
 
         self.file = file.filename if isinstance(file, h5py.File) else file
-        self.group = (group.name if isinstance(file, h5py.File) else group).rstrip("/")
-        self.name = name.lstrip("/")
+        self.group = (
+            (group.name if isinstance(file, h5py.File) else group).rstrip("/")
+            if group is not None
+            else None
+        )
+        self.name = name.lstrip("/") if name is not None else None
 
     def __str__(self) -> str:
-        return (
-            f"while writing object {self.group}/{self.name} to file {self.file}: "
-            + super().__str__()
-        )
+        if self.name is None:
+            msg = f"while opening file {self.file} for encoding: "
+        else:
+            msg = (
+                f"while encoding object {self.group}/{self.name} to file {self.file}: "
+            )
+        return msg + super().__str__()
 
     def __reduce__(self) -> tuple:  # for pickling.
         return self.__class__, (*self.args, self.file, self.group, self.name)

--- a/tests/lh5/test_exceptions.py
+++ b/tests/lh5/test_exceptions.py
@@ -1,8 +1,251 @@
 from __future__ import annotations
 
+import logging
 import pickle
+from pathlib import Path
 
+import h5py
+import numpy as np
+import pytest
+
+from lgdo import lh5, types
 from lgdo.lh5.exceptions import LH5DecodeError, LH5EncodeError
+
+
+def test_interact_with_already_open_files(tmptestdir):
+    thefile = tmptestdir / "already-open-file.lh5"
+    lh5.write(types.Struct({}), "/empty", thefile)
+
+    assert thefile.exists()
+
+    f = h5py.File(thefile, "r")
+    with pytest.raises(LH5EncodeError):
+        lh5.write(types.Struct({}), "/empty2", thefile)
+    f.close()
+
+    for mode in ("r", "r+", "w", "a"):
+        f = h5py.File(thefile, mode)
+        with pytest.raises(LH5DecodeError):
+            lh5.read("/empty", thefile)
+        f.close()
+
+
+def test_write_safe(tmptestdir):
+    # write_safe should create new file
+    struct = types.Struct()
+    struct.add_field("scalar", types.Scalar(value=10, attrs={"sth": 1}))
+    lh5.write(
+        struct,
+        "struct",
+        f"{tmptestdir}/tmp-pygama-write_safe_exception.lh5",
+        group="/data",
+        start_row=1,
+        n_rows=3,
+        wo_mode="w",
+    )
+
+    # write_safe should not allow writing to existing dataset
+    with pytest.raises(lh5.exceptions.LH5EncodeError):
+        lh5.write(
+            struct,
+            "struct",
+            f"{tmptestdir}/tmp-pygama-write_safe_exception.lh5",
+            group="/data",
+            start_row=1,
+            n_rows=3,
+            wo_mode="w",
+        )
+
+
+def test_open_non_existing_file(tmptestdir):
+    with pytest.raises(LH5DecodeError):
+        lh5.read("boh", tmptestdir / "beh.lh5")
+
+
+def test_open_non_existing_dataset(tmptestdir):
+    thefile = tmptestdir / "dummy-file.lh5"
+    lh5.write(types.Struct({}), "/empty", thefile)
+
+    with pytest.raises(LH5DecodeError):
+        lh5.read("/boh", thefile)
+
+
+def test_write_cleanup_on_error(tmptestdir):
+    outfile = tmptestdir / "cleanup_error.lh5"
+    h = types.Histogram(np.array([[1]]), (np.array([0, 1]), np.array([0, 1])))
+
+    lh5.write(h, "hist", outfile, wo_mode="overwrite_file")
+    with pytest.raises(lh5.exceptions.LH5EncodeError):
+        lh5.write(h, "hist", outfile, wo_mode="append")
+
+    # file should be closed so we can open it again
+    assert lh5.read("hist", outfile) is not None
+
+
+def test_write_append_struct(tmptestdir):
+    outfile = tmptestdir / "test-write-append-struct.lh5"
+    st = types.Struct({"arr1": types.Table({"a": types.Array([1, 2, 3])})})
+    lh5.write(st, "struct", outfile, wo_mode="of")
+    st2 = types.Struct({"arr2": types.Table({"a": types.Array([1, 2, 3])})})
+    lh5.write(st2, "struct", outfile, wo_mode="ac")
+
+    # test error when appending existing field
+    with pytest.raises(lh5.exceptions.LH5EncodeError):
+        lh5.write(
+            types.Struct({"arr2": types.Array([4, 5, 6])}),
+            "struct",
+            outfile,
+            wo_mode="ac",
+        )
+
+    # error if appending to object of different type
+    with pytest.raises(lh5.exceptions.LH5EncodeError):
+        lh5.write(
+            types.Struct({"arr2": types.Array([4, 5, 6])}),
+            "struct",
+            outfile,
+            wo_mode="ac",
+        )
+
+    lh5.write(
+        types.Table({"arr1": types.Array([1, 2, 3])}), "struct", outfile, wo_mode="of"
+    )
+
+    # error if appending to object of different type
+    with pytest.raises(lh5.exceptions.LH5EncodeError):
+        lh5.write(
+            types.Table({"arr2": types.Array([4, 5, 6, 7])}),
+            "struct",
+            outfile,
+            wo_mode="ac",
+        )
+
+
+# Test that when we try to overwrite an existing column in a table we fail
+def test_write_object_append_column(tmptestdir):
+    # Try to append an array to a table
+    if Path(f"{tmptestdir}/write_object_append_column_test.lh5").exists():
+        Path(f"{tmptestdir}/write_object_append_column_test.lh5").unlink()
+
+    array1 = types.Array(np.zeros(10))
+    tb1 = types.Table(col_dict={"dset1`": types.Array(np.ones(10))})
+    store = lh5.LH5Store()
+    store.write(array1, "my_table", f"{tmptestdir}/write_object_append_column_test.lh5")
+    with pytest.raises(lh5.exceptions.LH5EncodeError):
+        store.write(
+            tb1,
+            "my_table",
+            f"{tmptestdir}/write_object_append_column_test.lh5",
+            wo_mode="append_column",
+        )  # Now, try to append a column to an array
+
+    # Try to append a table that has a same key as the old table
+    if Path(f"{tmptestdir}/write_object_append_column_test.lh5").exists():
+        Path(f"{tmptestdir}/write_object_append_column_test.lh5").unlink()
+
+    tb1 = types.Table(
+        col_dict={
+            "dset1": types.Array(np.zeros(10)),
+            "dset2": types.Array(np.zeros(10)),
+        }
+    )
+    tb2 = types.Table(
+        col_dict={"dset2": types.Array(np.ones(10))}
+    )  # Same field name, different values
+    store = lh5.LH5Store()
+    store.write(tb1, "my_table", f"{tmptestdir}/write_object_append_column_test.lh5")
+    with pytest.raises(lh5.exceptions.LH5EncodeError):
+        store.write(
+            tb2,
+            "my_table",
+            f"{tmptestdir}/write_object_append_column_test.lh5",
+            wo_mode="append_column",
+        )  # Now, try to append a column with a same field
+
+    # try appending a column that is larger than one that exists
+    if Path(f"{tmptestdir}/write_object_append_column_test.lh5").exists():
+        Path(f"{tmptestdir}/write_object_append_column_test.lh5").unlink()
+
+    tb1 = types.Table(col_dict={"dset1": types.Array(np.zeros(10))})
+    tb2 = types.Table(
+        col_dict={"dset2": types.Array(np.ones(20))}
+    )  # different field name, different size
+    store = lh5.LH5Store()
+    store.write(tb1, "my_table", f"{tmptestdir}/write_object_append_column_test.lh5")
+    with pytest.raises(lh5.exceptions.LH5EncodeError):
+        store.write(
+            tb2,
+            "my_table",
+            f"{tmptestdir}/write_object_append_column_test.lh5",
+            wo_mode="append_column",
+        )  # Now, try to append a column with a different field size
+
+
+# Test writing and reading histograms.
+def test_write_histogram(caplog, tmptestdir):
+    caplog.set_level(logging.DEBUG)
+    caplog.clear()
+
+    # Start with an types.Histogram
+    if Path(f"{tmptestdir}/write_histogram_test.lh5").exists():
+        Path(f"{tmptestdir}/write_histogram_test.lh5").unlink()
+
+    h1 = types.Histogram(
+        np.array([[1, 1], [1, 1]]), (np.array([0, 1, 2]), np.array([2.1, 2.2, 2.3]))
+    )
+    h2 = types.Histogram(
+        np.array([[10, 10], [10, 10]]),
+        (np.array([2, 3, 4]), np.array([5, 6, 7])),
+        isdensity=True,
+    )
+    h2.binning[0]["binedges"].attrs["units"] = "ns"
+
+    # Same field name, different values
+    store = lh5.LH5Store()
+    # "appending" to a non-existing histogram should work.
+    store.write(
+        h1,
+        "my_histogram",
+        f"{tmptestdir}/write_histogram_test.lh5",
+        group="my_group",
+        wo_mode="append",
+    )
+    with pytest.raises(lh5.exceptions.LH5EncodeError):
+        # appending to an existing histogram should not work.
+        store.write(
+            h1,
+            "my_histogram",
+            f"{tmptestdir}/write_histogram_test.lh5",
+            group="my_group",
+            wo_mode="append",
+        )
+    store.write(
+        h2,
+        "my_histogram",
+        f"{tmptestdir}/write_histogram_test.lh5",
+        wo_mode="overwrite",
+        group="my_group",
+    )
+
+    # Now, check that writing with other modes throws.
+    for disallowed_wo_mode in ["append", "append_column"]:
+        with pytest.raises(lh5.exceptions.LH5EncodeError):
+            store.write(
+                h2,
+                "my_histogram",
+                f"{tmptestdir}/write_histogram_test.lh5",
+                wo_mode=disallowed_wo_mode,
+                group="my_group",
+            )
+    with pytest.raises(lh5.exceptions.LH5EncodeError):
+        store.write(
+            h2,
+            "my_histogram",
+            f"{tmptestdir}/write_histogram_test.lh5",
+            wo_mode="overwrite",
+            write_start=1,
+            group="my_group",
+        )
 
 
 def test_pickle():


### PR DESCRIPTION
## Summary
- close HDF5 files in core read path when opened internally
- close HDF5 files on write errors

## Testing
- `pre-commit run --files src/lgdo/lh5/core.py src/lgdo/lh5/_serializers/write/composite.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a6078a5c833098c0be9ef143d46f