### PR TITLE
support units in view_as("ak")

### DIFF
--- a/src/lgdo/types/array.py
+++ b/src/lgdo/types/array.py
@@ -239,7 +239,6 @@ class Array(LGDOCollection):
         --------
         .LGDO.view_as
         """
-        # TODO: does attaching units imply a copy?
         attach_units = with_units and "units" in self.attrs
 
         if library == "pd":
@@ -260,17 +259,17 @@ class Array(LGDOCollection):
 
         if library == "np":
             if attach_units:
+                # TODO: does attaching units imply a copy?
                 return self.nda * u(self.attrs["units"])
 
             return self.nda
 
         if library == "ak":
+            ak_arr = ak.Array(self.nda)  # NOTE: this is zero-copy!
             if attach_units:
-                msg = "Pint does not support Awkward yet, you must view the data with_units=False"
-                raise ValueError(msg)
+                ak_arr = ak.with_parameter(ak_arr, "units", self.attrs["units"])
 
-            # NOTE: this is zero-copy!
-            return ak.Array(self.nda)
+            return ak_arr
 
         msg = f"{library} is not a supported third-party format."
         raise ValueError(msg)

--- a/src/lgdo/types/encoded.py
+++ b/src/lgdo/types/encoded.py
@@ -252,12 +252,8 @@ class VectorOfEncodedVectors(LGDOCollection):
         attach_units = with_units and "units" in self.attrs
 
         if library == "ak":
-            if attach_units:
-                msg = "Pint does not support Awkward yet, you must view the data with_units=False"
-                raise ValueError(msg)
-
             records_list = {
-                "encoded_data": self.encoded_data.view_as("ak"),
+                "encoded_data": self.encoded_data.view_as("ak", with_units=with_units),
                 "decoded_size": np.array(self.decoded_size),
             }
             return ak.Array(records_list)
@@ -483,12 +479,8 @@ class ArrayOfEncodedEqualSizedArrays(LGDOCollection):
         attach_units = with_units and "units" in self.attrs
 
         if library == "ak":
-            if attach_units:
-                msg = "Pint does not support Awkward yet, you must view the data with_units=False"
-                raise ValueError(msg)
-
             records_list = {
-                "encoded_data": self.encoded_data.view_as("ak"),
+                "encoded_data": self.encoded_data.view_as("ak", with_units=with_units),
                 "decoded_size": np.full(
                     len(self.encoded_data.cumulative_length), self.decoded_size.value
                 ),

--- a/src/lgdo/types/encoded.py
+++ b/src/lgdo/types/encoded.py
@@ -249,13 +249,19 @@ class VectorOfEncodedVectors(LGDOCollection):
         --------
         .LGDO.view_as
         """
-        attach_units = with_units and "units" in self.attrs
+        attach_units = with_units and (
+            "units" in self.attrs or "units" in self.encoded_data.attrs
+        )
 
         if library == "ak":
             records_list = {
                 "encoded_data": self.encoded_data.view_as("ak", with_units=with_units),
                 "decoded_size": np.array(self.decoded_size),
             }
+            if "units" in self.attrs:
+                records_list["encoded_data"] = ak.with_parameter(
+                    records_list["encoded_data"], "units", self.attrs["units"]
+                )
             return ak.Array(records_list)
 
         if library == "np":
@@ -476,7 +482,9 @@ class ArrayOfEncodedEqualSizedArrays(LGDOCollection):
         --------
         .LGDO.view_as
         """
-        attach_units = with_units and "units" in self.attrs
+        attach_units = with_units and (
+            "units" in self.attrs or "units" in self.encoded_data.attrs
+        )
 
         if library == "ak":
             records_list = {
@@ -485,6 +493,10 @@ class ArrayOfEncodedEqualSizedArrays(LGDOCollection):
                     len(self.encoded_data.cumulative_length), self.decoded_size.value
                 ),
             }
+            if "units" in self.attrs:
+                records_list["encoded_data"] = ak.with_parameter(
+                    records_list["encoded_data"], "units", self.attrs["units"]
+                )
             return ak.Array(records_list)
 
         if library == "np":

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -534,14 +534,12 @@ class Table(Struct, LGDOCollection):
             raise TypeError(msg)
 
         if library == "ak":
-            if with_units:
-                msg = "Pint does not support Awkward yet, you must view the data with_units=False"
-                raise ValueError(msg)
-
-            # NOTE: passing the Table directly (which inherits from a dict)
-            # makes it somehow really slow. Not sure why, but this could be due
-            # to extra LGDO fields (like "attrs")
-            return ak.Array({col: self[col].view_as("ak") for col in cols})
+            # NOTE: passing the Table directly (which inherits from a dict) makes it
+            # somehow really slow. ak.Array can unroll dicts just fine, but then uses
+            # ak.from_iter to convert the arrays, instead of a zero-copy operation.
+            return ak.Array(
+                {col: self[col].view_as("ak", with_units=with_units) for col in cols}
+            )
 
         msg = f"{library!r} is not a supported third-party format."
         raise TypeError(msg)

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -296,6 +296,7 @@ class Table(Struct, LGDOCollection):
         expr: str,
         parameters: Mapping[str, str] | None = None,
         modules: Mapping[str, ModuleType] | None = None,
+        with_units: bool = False,
     ) -> LGDO:
         """Apply column operations to the table and return a new LGDO.
 
@@ -334,6 +335,8 @@ class Table(Struct, LGDOCollection):
             is not `None` then :func:`eval`is used and the expression can
             depend on any modules from this dictionary in addition to awkward
             and numpy. These are passed to :func:`eval` as `globals` argument.
+        with_units
+            attach units to the columns as in :meth:`Table.eval`.
 
         Examples
         --------
@@ -366,10 +369,14 @@ class Table(Struct, LGDOCollection):
         for obj in c.co_names:
             if obj in flat_self:
                 if isinstance(flat_self[obj], VectorOfVectors):
-                    self_unwrap[obj] = flat_self[obj].view_as("ak", with_units=False)
+                    self_unwrap[obj] = flat_self[obj].view_as(
+                        "ak", with_units=with_units
+                    )
                     has_ak = True
                 else:
-                    self_unwrap[obj] = flat_self[obj].view_as("np", with_units=False)
+                    self_unwrap[obj] = flat_self[obj].view_as(
+                        "np", with_units=with_units
+                    )
 
         msg = f"evaluating {expr!r} with locals={(self_unwrap | parameters)} and {has_ak=}"
         log.debug(msg)

--- a/src/lgdo/types/vectorofvectors.py
+++ b/src/lgdo/types/vectorofvectors.py
@@ -646,10 +646,6 @@ class VectorOfVectors(LGDOCollection):
         attach_units = with_units and "units" in self.attrs
 
         if library == "ak":
-            if attach_units:
-                msg = "Pint does not support Awkward yet, you must view the data with_units=False"
-                raise ValueError(msg)
-
             # see https://github.com/scikit-hep/awkward/discussions/2848
 
             # cannot avoid making a copy here. we should add the leading 0 to
@@ -689,7 +685,12 @@ class VectorOfVectors(LGDOCollection):
                 offsets=ak.index.Index(offsets),
                 content=content,
             )
-            return ak.Array(layout)
+            ak_arr = ak.Array(layout)
+
+            if attach_units:
+                ak_arr = ak.with_parameter(ak_arr, "units", self.attrs["units"])
+
+            return ak_arr
 
         if library == "np":
             if preserve_dtype:

--- a/tests/types/test_array.py
+++ b/tests/types/test_array.py
@@ -89,8 +89,9 @@ def test_view():
     v = a.view_as("ak", with_units=False)
     assert isinstance(v, ak.Array)
 
-    with pytest.raises(ValueError):
-        a.view_as("ak", with_units=True)
+    v = a.view_as("ak", with_units=True)
+    assert isinstance(v, ak.Array)
+    assert ak.parameters(v) == {"units": "m"}
 
 
 def test_pickle():

--- a/tests/types/test_arrayofequalsizedarrays.py
+++ b/tests/types/test_arrayofequalsizedarrays.py
@@ -68,5 +68,6 @@ def test_view():
     with pytest.raises(ValueError):
         aoesa.view_as("pd", with_units=True)
 
-    with pytest.raises(ValueError):
-        aoesa.view_as("ak", with_units=True)
+    v = aoesa.view_as("ak", with_units=True)
+    assert isinstance(v, ak.Array)
+    assert ak.parameters(v) == {"units": "m"}

--- a/tests/types/test_encoded.py
+++ b/tests/types/test_encoded.py
@@ -241,6 +241,14 @@ def test_voev_view_as():
     )
     assert ak.all(ak_arr.decoded_size == [6, 6, 6, 6, 6])
 
+    ak_arr = voev.view_as("ak", with_units=True)
+    assert ak.parameters(ak_arr.encoded_data) == {"units": "s"}
+
+    voev.encoded_data.attrs["units"] = voev.attrs["units"]
+    del voev.attrs["units"]
+    ak_arr = voev.view_as("ak", with_units=True)
+    assert ak.parameters(ak_arr.encoded_data) == {"units": "s"}
+
     df = voev.view_as("pd", with_units=False)
     assert isinstance(df, pd.DataFrame)
     assert isinstance(df.encoded_data.ak, akpd.accessor.AwkwardAccessor)
@@ -276,6 +284,14 @@ def test_aoeesa_view_as():
         ]
     )
     assert ak.all(ak_arr.decoded_size == [99, 99, 99, 99, 99])
+
+    ak_arr = voev.view_as("ak", with_units=True)
+    assert ak.parameters(ak_arr.encoded_data) == {"units": "s"}
+
+    voev.encoded_data.attrs["units"] = voev.attrs["units"]
+    del voev.attrs["units"]
+    ak_arr = voev.view_as("ak", with_units=True)
+    assert ak.parameters(ak_arr.encoded_data) == {"units": "s"}
 
     df = voev.view_as("pd", with_units=False)
     assert isinstance(df, pd.DataFrame)

--- a/tests/types/test_table.py
+++ b/tests/types/test_table.py
@@ -215,8 +215,10 @@ def test_view_as():
     assert isinstance(ak_arr, ak.Array)
     assert list(ak_arr.fields) == ["a", "b", "c", "d"]
 
-    with pytest.raises(ValueError):
-        tbl.view_as("ak", with_units=True)
+    ak_arr = tbl.view_as("ak", with_units=True)
+    assert isinstance(ak_arr, ak.Array)
+    assert list(ak_arr.fields) == ["a", "b", "c", "d"]
+    assert ak.parameters(ak_arr.d.a) == {"units": "m"}
 
     with pytest.raises(TypeError):
         tbl.view_as("np")

--- a/tests/types/test_vectorofvectors.py
+++ b/tests/types/test_vectorofvectors.py
@@ -447,9 +447,10 @@ def test_iter(testvov):
 def test_view_as(testvov):
     v2d = testvov.v2d
 
-    v2d.attrs["units"] = "s"
-    with pytest.raises(ValueError):
-        v2d.view_as("ak", with_units=True)
+    v2d.flattened_data.attrs["units"] = "s"
+    ak_arr = v2d.view_as("ak", with_units=True)
+    assert isinstance(ak_arr, ak.Array)
+    assert ak.parameters(ak_arr) == {"units": "s"}
 
     ak_arr = v2d.view_as("ak", with_units=False)
 

--- a/tests/types/test_vectorofvectors.py
+++ b/tests/types/test_vectorofvectors.py
@@ -445,35 +445,37 @@ def test_iter(testvov):
 
 
 def test_view_as(testvov):
-    v2d = testvov.v2d
+    v2ds = [copy.deepcopy(testvov.v2d), copy.deepcopy(testvov.v2d)]
+    v2ds[0].attrs["units"] = "s"
+    v2ds[1].flattened_data.attrs["units"] = "s"
 
-    v2d.flattened_data.attrs["units"] = "s"
-    ak_arr = v2d.view_as("ak", with_units=True)
-    assert isinstance(ak_arr, ak.Array)
-    assert ak.parameters(ak_arr) == {"units": "s"}
+    for v2d in v2ds:
+        ak_arr = v2d.view_as("ak", with_units=True)
+        assert isinstance(ak_arr, ak.Array)
+        assert ak.parameters(ak_arr) == {"units": "s"}
 
-    ak_arr = v2d.view_as("ak", with_units=False)
+        ak_arr = v2d.view_as("ak", with_units=False)
 
-    assert isinstance(ak_arr, ak.Array)
-    assert ak.is_valid(ak_arr)
-    assert len(ak_arr) == len(v2d)
-    assert ak.all(ak_arr == [[1, 2], [3, 4, 5], [2], [4, 8, 9, 7], [5, 3, 1]])
+        assert isinstance(ak_arr, ak.Array)
+        assert ak.is_valid(ak_arr)
+        assert len(ak_arr) == len(v2d)
+        assert ak.all(ak_arr == [[1, 2], [3, 4, 5], [2], [4, 8, 9, 7], [5, 3, 1]])
 
-    np_arr = v2d.view_as("np", with_units=True)
-    assert isinstance(np_arr, pint.Quantity)
-    assert np_arr.u == "second"
-    assert isinstance(np_arr.m, np.ndarray)
+        np_arr = v2d.view_as("np", with_units=True)
+        assert isinstance(np_arr, pint.Quantity)
+        assert np_arr.u == "second"
+        assert isinstance(np_arr.m, np.ndarray)
 
-    np_arr = v2d.view_as("np", with_units=False)
-    assert isinstance(np_arr, np.ndarray)
-    assert np.issubdtype(np_arr.dtype, np.floating)
+        np_arr = v2d.view_as("np", with_units=False)
+        assert isinstance(np_arr, np.ndarray)
+        assert np.issubdtype(np_arr.dtype, np.floating)
 
-    np_arr = v2d.view_as("np", with_units=False, fill_val=0, preserve_dtype=True)
-    assert np.issubdtype(np_arr.dtype, np.integer)
+        np_arr = v2d.view_as("np", with_units=False, fill_val=0, preserve_dtype=True)
+        assert np.issubdtype(np_arr.dtype, np.integer)
 
-    np_arr = v2d.view_as("pd", with_units=False)
-    assert isinstance(np_arr, pd.Series)
-    assert isinstance(np_arr.ak, akpd.accessor.AwkwardAccessor)
+        np_arr = v2d.view_as("pd", with_units=False)
+        assert isinstance(np_arr, pd.Series)
+        assert isinstance(np_arr.ak, akpd.accessor.AwkwardAccessor)
 
     v3d = testvov.v3d
 


### PR DESCRIPTION
this is only very preliminary support, it does not work as with numpy and pint: the user is responsible for correctly converting and using the attached units. Still, this should be an improvement over the current situation.

also fix the view_as functions independent of where the units are attached (i.e., on the highlevel object or the actual data array, see recent spec change)