### PR TITLE
Lazy load modules with numba

### DIFF
--- a/src/lgdo/compression/__init__.py
+++ b/src/lgdo/compression/__init__.py
@@ -24,15 +24,36 @@ interface for encoding/decoding :class:`~.lgdo.LGDO`\ s.
 
 from __future__ import annotations
 
+from importlib import import_module
+
 from .base import WaveformCodec
 from .generic import decode, encode
-from .radware import RadwareSigcompress
-from .varlen import ULEB128ZigZagDiff
 
-__all__ = [
-    "RadwareSigcompress",
-    "ULEB128ZigZagDiff",
+# mapping from codec class to module for lazy loading
+_codec_classes = {
+    "RadwareSigcompress": "radware",
+    "ULEB128ZigZagDiff": "varlen",
+}
+
+__all__ = list(_codec_classes)
+__all__ += [
     "WaveformCodec",
     "decode",
     "encode",
 ]
+
+
+# Lazy loader
+def __getattr__(name):
+    if name in _codec_classes:
+        mod_name = _codec_classes[name]
+        mod = import_module(f".{mod_name}", __name__)
+        codec = getattr(mod, name)
+        globals().update({name: codec})
+        return codec
+    msg = f"module {__name__} has no attribute {name}"
+    raise AttributeError(msg)
+
+
+def __dir__():
+    return __all__ + list(globals().keys())

--- a/src/lgdo/compression/generic.py
+++ b/src/lgdo/compression/generic.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 
 from .. import types as lgdo
-from . import radware, varlen
 from .base import WaveformCodec
 
 log = logging.getLogger(__name__)
@@ -25,6 +24,8 @@ def encode(
         algorithm to be used for encoding.
     """
     log.debug(f"encoding {obj!r} with {codec}")
+
+    from . import radware, varlen  # noqa: PLC0415
 
     if _is_codec(codec, radware.RadwareSigcompress):
         enc_obj = radware.encode(obj, shift=codec.codec_shift)
@@ -65,6 +66,8 @@ def decode(
 
     codec = obj.attrs["codec"]
     log.debug(f"decoding {obj!r} with {codec}")
+
+    from . import radware, varlen  # noqa: PLC0415
 
     if _is_codec(codec, radware.RadwareSigcompress):
         return radware.decode(

--- a/src/lgdo/compression/utils.py
+++ b/src/lgdo/compression/utils.py
@@ -4,8 +4,6 @@ import re
 import sys
 
 from .base import WaveformCodec
-from .radware import RadwareSigcompress  # noqa: F401
-from .varlen import ULEB128ZigZagDiff  # noqa: F401
 
 
 def str2wfcodec(expr: str) -> WaveformCodec:
@@ -20,7 +18,7 @@ def str2wfcodec(expr: str) -> WaveformCodec:
         raise ValueError(msg)
 
     match = match.groups()
-    codec = getattr(sys.modules[__name__], match[0].strip())
+    codec = getattr(sys.modules[".".join(__name__.split(".")[:-1])], match[0].strip())
     args = {}
 
     if match[1]:

--- a/src/lgdo/types/vovutils.py
+++ b/src/lgdo/types/vovutils.py
@@ -1,11 +1,13 @@
-""":class:`~.lgdo.typing.vectorofvectors.VectorOfVectors` utilities."""
+""":class:`~.lgdo.typing.vectorofvectors.VectorOfVectors` utilities.
+Note: importing this module takes a long time, so it should be lazily
+imported inside of a function call rather than with a full module
+"""
 
 from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
 
-import awkward as ak
 import numba
 import numpy as np
 from numpy.typing import NDArray
@@ -284,47 +286,3 @@ def explode_arrays(
     for ii in range(len(arrays)):
         explode(cumulative_length, arrays[ii], arrays_out[ii])
     return arrays_out
-
-
-def _ak_is_jagged(type_: ak.types.Type) -> bool:
-    """Returns ``True`` if :class:`ak.Array` is jagged at all axes.
-
-    This assures that :func:`ak.to_buffers` returns the expected data
-    structures.
-    """
-    if isinstance(type_, ak.Array):
-        return _ak_is_jagged(type_.type)
-
-    if isinstance(type_, (ak.types.ArrayType, ak.types.ListType)):
-        return _ak_is_jagged(type_.content)
-
-    if isinstance(type_, ak.types.ScalarType):
-        msg = "Expected ArrayType or its content"
-        raise TypeError(msg)
-
-    return not isinstance(type_, ak.types.RegularType)
-
-
-# https://github.com/scikit-hep/awkward/discussions/3049
-def _ak_is_valid(type_: ak.types.Type) -> bool:
-    """Returns ``True`` if :class:`ak.Array` contains only elements we can serialize to LH5."""
-    if isinstance(type_, ak.Array):
-        return _ak_is_valid(type_.type)
-
-    if isinstance(type_, (ak.types.ArrayType, ak.types.ListType)):
-        return _ak_is_valid(type_.content)
-
-    if isinstance(type_, ak.types.ScalarType):
-        msg = "Expected ArrayType or its content"
-        raise TypeError(msg)
-
-    return not isinstance(
-        type_,
-        (
-            ak.types.OptionType,
-            ak.types.UnionType,
-            ak.types.RecordType,
-        ),
-    )
-
-    return isinstance(type_, ak.types.NumpyType)

--- a/tests/types/test_vectorofvectors.py
+++ b/tests/types/test_vectorofvectors.py
@@ -584,3 +584,19 @@ def test_bytestrings():
     # test bytestring with ak Array
     ak_arr = v.view_as("ak", with_units=False)
     assert len(ak_arr[0]) == 0
+
+
+def test_ak_input_validity(testvov):
+    for v in testvov:
+        assert VectorOfVectors._ak_is_jagged(v) is True
+        assert VectorOfVectors._ak_is_valid(v) is True
+
+    assert VectorOfVectors._ak_is_jagged(ak.Array([[1], [1, 2], [1, 3, 4]])) is True
+    assert VectorOfVectors._ak_is_jagged(ak.Array(np.empty(shape=(2, 3, 4)))) is False
+
+    assert VectorOfVectors._ak_is_valid(ak.Array([[1], [1, 2], [1, 3, 4]])) is True
+    assert VectorOfVectors._ak_is_valid(ak.Array(np.empty(shape=(2, 3, 4)))) is True
+    assert (
+        VectorOfVectors._ak_is_valid(ak.Array([[1, None], [1, 2], [1, 3, 4]])) is False
+    )
+    assert VectorOfVectors._ak_is_valid(ak.Array({"a": [1, 2], "b": [3, 4]})) is False

--- a/tests/types/test_vovutils.py
+++ b/tests/types/test_vovutils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections import namedtuple
 
-import awkward as ak
 import numpy as np
 import pytest
 
@@ -77,20 +76,6 @@ def test_nb_fill():
         flattened_array_out,
         np.array([1, 2, 3, 0, 4, 5, 6], dtype=aoa_in[0].dtype),
     )
-
-
-def test_ak_input_validity(testvov):
-    for v in testvov:
-        assert vovutils._ak_is_jagged(v) is True
-        assert vovutils._ak_is_valid(v) is True
-
-    assert vovutils._ak_is_jagged(ak.Array([[1], [1, 2], [1, 3, 4]])) is True
-    assert vovutils._ak_is_jagged(ak.Array(np.empty(shape=(2, 3, 4)))) is False
-
-    assert vovutils._ak_is_valid(ak.Array([[1], [1, 2], [1, 3, 4]])) is True
-    assert vovutils._ak_is_valid(ak.Array(np.empty(shape=(2, 3, 4)))) is True
-    assert vovutils._ak_is_valid(ak.Array([[1, None], [1, 2], [1, 3, 4]])) is False
-    assert vovutils._ak_is_valid(ak.Array({"a": [1, 2], "b": [3, 4]})) is False
 
 
 def test_build_cl_and_explodes():


### PR DESCRIPTION
Supersedes #190.
Closes #86.

Lazy importing for numba functions in vovutils and the compression subpackage. This speeds up the package loading, although it still isn't quite instantaneous.

- vovutils is already not imported within types, unless done so explicitly. It was being imported with VectorOfVectors, so I moved the import inside of the function in which it was called
- The _ak_is_jagged and _ak_is_valid functions were moved out of vovutils; they do not utilize numba, so lazy-loading is not needed. They are now staticmethods of VectorOfVectors
- For compression, I used the approach used for dspeed, which is to add a lazy-loader to __init__ for the codec classes
- I also had to make sure that the codec classes were only imported inside of functions:
  - in generic, import the codec classes inside of the functions
  - in utils, instead of importing the functions at the start and loading them in the function, import and load in the function

This was also tested by adding print lines at the start of the vovutils, radware, and varlen compression modules; they do not print when importing just lgdo, but do when loading/running code that actually uses them 