### PR TITLE
Added multi-processing capabilities to LH5Iterator, including map, query, and hist functions

### DIFF
--- a/src/lgdo/types/__init__.py
+++ b/src/lgdo/types/__init__.py
@@ -7,7 +7,7 @@ from .arrayofequalsizedarrays import ArrayOfEqualSizedArrays
 from .encoded import ArrayOfEncodedEqualSizedArrays, VectorOfEncodedVectors
 from .fixedsizearray import FixedSizeArray
 from .histogram import Histogram
-from .lgdo import LGDO
+from .lgdo import LGDO, LGDOCollection
 from .scalar import Scalar
 from .struct import Struct
 from .table import Table
@@ -21,6 +21,7 @@ __all__ = [
     "ArrayOfEqualSizedArrays",
     "FixedSizeArray",
     "Histogram",
+    "LGDOCollection",
     "Scalar",
     "Struct",
     "Table",

--- a/tests/types/test_vectorofvectors.py
+++ b/tests/types/test_vectorofvectors.py
@@ -454,6 +454,24 @@ def test_set_vector_unsafe(testvov):
             == np.nan_to_num(exp_entry_w_overflow, nan=0)
         )
 
+        # test vectorized filling when len is longer than array
+        fourth_vov = lgdo.VectorOfVectors(
+            shape_guess=(5, 5), dtype=current_testvov.dtype
+        )
+        desired_lens[3] = 10
+        fourth_vov._set_vector_unsafe(0, desired_aoa, desired_lens)
+        if current_testvov.dtype in ["int32", "int64", "uint16", "uint32"]:
+            exp_entry_w_overflow = np.concatenate(
+                [desired[3], np.array([np.iinfo(current_testvov.dtype).min] * 6)]
+            )
+        else:
+            exp_entry_w_overflow = np.concatenate([desired[3], np.array([np.nan] * 6)])
+
+        assert np.all(
+            np.nan_to_num(fourth_vov[3], nan=0)
+            == np.nan_to_num(exp_entry_w_overflow, nan=0)
+        )
+
 
 def test_iter(testvov):
     testvov = testvov.v2d


### PR DESCRIPTION
Added functions to LH5Iterator:
**map** takes an input function with arguments of type Table and LH5Iterator and applies it to each block of data, returning a list of the results (similar to the python builtin map). In addition, the user can provide:
  - An aggregator function that will in some way combine the results of this function (e.g., can join tables column wise or add together results).
  - Begin and terminate functions to do things before loops begin/end
  - Either a concurrent.futures.Executor or a number of processes to run (using ProcessPoolExecutor). This will divide the iterator into equal(ish) sized chunks of files/groups and submit each chunk to the Executor. If this is used, results will be returned as an iterator over futures objects (see concurrent.futures.Executor.map)

**query** takes an input function with arguments of type Table and LH5Iterator and returns a Table, pandas dataframe, awkward array, or numpy array with some sort of processing (including down-selection) applied. This function is mapped over the full dataset pointed to by the iterator, and the results are merged into a single Table/dataframe/awkward array. This can be used with multiprocessing.

  - In addition, a pandas query can be provided as a string; this will return a pandas dataframe with the query used to select which entries to include. This feature could be expanded for awkward and other datatypes in the future (see 

    https://github.com/legend-exp/legend-pydataobj/issues/135 for why this is not done yet)

**hist** takes a list of Hist.axis specifications, a query function/str, and a list of keys, and builds a histogram out of the queried data (filling it iteratively so that we never have to hold the full table in memory at once). This can be used with multiprocessing.

In addition, some other functions were implemented to support these:

  - __deepcopy__ is defined; this deep-copies everything except LH5Store, for which a new Store is constructed (since h5py objects are not all deepcopy-able)
  - __getstate__ and __setstate__ are defined to enable pickling of an LH5Iterator. Pickling is used by multiprocessing to communicate data from the parent process to child processes. This requires skipping the LH5Store when writing, and constructing a new one when reading.
  - _select_groups is a helper function that reduces the files and groups iterated over to some slice. This is used by...
  - _generate_workers splits the iterator into n equal(ish) iterators that are passed to each of the processes when using multi-processing
  - Additional helper functions used by map, query, and hist

Added tests for map, query and hist.