### PR TITLE
modernize license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=61.2",
+    "setuptools>=77",
     "setuptools_scm[toml]>=7"
 ]
 build-backend = "setuptools.build_meta"
@@ -15,12 +15,12 @@ maintainers = [
     { name = "The LEGEND Collaboration" },
 ]
 readme = "README.md"
-license.file = "LICENSE"
+license = "GPL-3.0"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: MacOS",
     "Operating System :: POSIX",
     "Operating System :: Unix",
@@ -86,9 +86,6 @@ lh5concat = "lgdo.cli:lh5concat_cli"
 [tool.setuptools]
 include-package-data = true
 zip-safe = false
-license-files = [
-    "LICENSE",
-]
 
 [tool.setuptools.package-dir]
 "" = "src"


### PR DESCRIPTION
without these changes, the package will not build after the setuptools release in February 2026. Note that setuptools v77 is only from this March, so it is quite recent