### PR TITLE
Replace cumulative_length with _OffsetArrayView to _offsets

### DIFF
--- a/src/lgdo/types/vectorofvectors.py
+++ b/src/lgdo/types/vectorofvectors.py
@@ -92,6 +92,8 @@ class VectorOfVectors(LGDOCollection):
         data: ArrayLike | None = None,
         flattened_data: ArrayLike | None = None,
         cumulative_length: ArrayLike | VectorOfVectors | None = None,
+        *,
+        offsets: ArrayLike | None = None,
         shape_guess: Sequence[int, ...] | None = None,
         dtype: DTypeLike | None = None,
         fill_val: int | float | None = None,
@@ -117,6 +119,10 @@ class VectorOfVectors(LGDOCollection):
             `self.cumulative_length`. Should be `dtype` :any:`numpy.uint32`. If
             `cumulative_length` is ``None``, an internal `cumulative_length` is
             allocated based on the first element of `shape_guess`.
+        offsets
+            if not ``None``, used directly as the internal offsets array
+            (PyArrow-compatible format with leading 0). Takes priority over
+            `cumulative_length`. Mutually exclusive with `cumulative_length`.
         shape_guess
             a NumPy-format shape specification, required if either of
             `flattened_data` or `cumulative_length` are not supplied.  The
@@ -133,6 +139,11 @@ class VectorOfVectors(LGDOCollection):
             a set of user attributes to be carried along with this LGDO.
         """
         # sanitize
+        if offsets is not None and cumulative_length is not None:
+            msg = "offsets and cumulative_length are mutually exclusive"
+            raise ValueError(msg)
+        if offsets is not None and not isinstance(offsets, Array):
+            offsets = Array(offsets)
         if cumulative_length is not None and not isinstance(cumulative_length, Array):
             cumulative_length = Array(cumulative_length)
         if flattened_data is not None and not isinstance(
@@ -239,8 +250,11 @@ class VectorOfVectors(LGDOCollection):
             self.flattened_data = None
             self.cumulative_length = None
 
-            # let's first setup cumulative_length...
-            if cumulative_length is None:
+            # let's first setup cumulative_length/offsets...
+            if offsets is not None:
+                # use offsets directly (PyArrow-compatible format)
+                self._offsets = offsets
+            elif cumulative_length is None:
                 # initialize based on shape_guess
                 if shape_guess is None:
                     # just make an empty 2D vector

--- a/src/lgdo/types/vectorofvectors.py
+++ b/src/lgdo/types/vectorofvectors.py
@@ -24,6 +24,39 @@ from .lgdo import LGDOCollection
 log = logging.getLogger(__name__)
 
 
+class _OffsetArrayView(Array):
+    """Array view into offsets[1:] that delegates mutations to the parent offsets."""
+
+    def __init__(self, offsets: Array) -> None:
+        self._parent_offsets = offsets
+        super().__init__(nda=offsets.nda[1:])
+
+    def _refresh_view(self) -> None:
+        self._nda = self._parent_offsets.nda[1:]
+        self._size = len(self._parent_offsets) - 1
+
+    def resize(self, new_size: int, trim: bool = False) -> None:
+        self._parent_offsets.resize(new_size + 1, trim)
+        self._refresh_view()
+
+    def reserve_capacity(self, capacity: int) -> None:
+        self._parent_offsets.reserve_capacity(capacity + 1)
+        self._refresh_view()
+
+    def get_capacity(self) -> int:
+        return self._parent_offsets.get_capacity() - 1
+
+    def trim_capacity(self) -> None:
+        self._parent_offsets.trim_capacity()
+        self._refresh_view()
+
+    def insert(self, i: int, value: Array | np.ndarray) -> None:
+        if isinstance(value, Array):
+            value = value.nda
+        self._parent_offsets.insert(i + 1, value)
+        self._refresh_view()
+
+
 class VectorOfVectors(LGDOCollection):
     """A n-dimensional variable-length 1D array of variable-length 1D arrays.
 
@@ -278,6 +311,25 @@ class VectorOfVectors(LGDOCollection):
             else self.flattened_data.form_datatype()
         )
         return "array<1>{" + eltype + "}"
+
+    @property
+    def cumulative_length(self) -> Array:
+        """Return an Array view of offsets[1:] for backwards compatibility."""
+        return _OffsetArrayView(self._offsets)
+
+    @cumulative_length.setter
+    def cumulative_length(self, value) -> None:
+        """Set cumulative_length by converting to offsets with leading 0."""
+        if value is None:
+            self._offsets = None
+            return
+        if isinstance(value, Array):
+            value = value.nda
+        value = np.asarray(value)
+        offsets = np.empty(len(value) + 1, dtype=value.dtype)
+        offsets[0] = 0
+        offsets[1:] = value
+        self._offsets = Array(nda=offsets)
 
     def __len__(self) -> int:
         """Return the number of stored vectors along the first axis (0)."""
@@ -726,16 +778,8 @@ class VectorOfVectors(LGDOCollection):
         )
 
         if library == "ak":
-            # see https://github.com/scikit-hep/awkward/discussions/2848
-
-            # cannot avoid making a copy here. we should add the leading 0 to
-            # cumulative_length inside VectorOfVectors at some point in the
-            # future
-            offsets = np.empty(
-                len(self.cumulative_length) + 1, dtype=self.cumulative_length.dtype
-            )
-            offsets[1:] = self.cumulative_length.nda
-            offsets[0] = 0
+            # use internal offsets directly (includes leading 0)
+            offsets = self._offsets.nda
 
             if self.ndim != 2:
                 content = self.flattened_data.view_as(

--- a/tests/types/test_vectorofvectors.py
+++ b/tests/types/test_vectorofvectors.py
@@ -195,34 +195,6 @@ def test_serialization(testvov):
     assert np.array_equal(testvov.v3d._offsets.nda, [0, 2, 4, 5])
 
 
-def test_lh5_roundtrip_offsets(tmp_path):
-    """Test that VectorOfVectors round-trips through LH5 without extra copies."""
-    # Create VoV with offsets
-    offsets = np.array([0, 2, 5, 6, 10, 13], dtype="int64")
-    flattened = Array([1, 2, 3, 4, 5, 2, 4, 8, 9, 7, 5, 3, 1])
-    vov = VectorOfVectors(flattened_data=flattened, offsets=offsets)
-
-    # Write and read back
-    fname = tmp_path / "test_vov.lh5"
-    lh5.write(vov, "vov", fname)
-    vov2 = lh5.read("vov", fname)
-
-    # Verify data integrity
-    assert np.array_equal(vov._offsets.nda, vov2._offsets.nda)
-    assert np.array_equal(vov.flattened_data.nda, vov2.flattened_data.nda)
-    assert vov == vov2
-
-    # Test with cumulative_length construction for comparison
-    vov3 = VectorOfVectors(
-        flattened_data=flattened,
-        cumulative_length=Array([2, 5, 6, 10, 13]),
-    )
-    lh5.write(vov3, "vov3", fname, wo_mode="a")
-    vov4 = lh5.read("vov3", fname)
-    assert vov3 == vov4
-    assert np.array_equal(vov3._offsets.nda, vov4._offsets.nda)
-
-
 def test_datatype_name(testvov):
     for v in testvov:
         assert v.datatype_name() == "array"

--- a/tests/types/test_vectorofvectors.py
+++ b/tests/types/test_vectorofvectors.py
@@ -106,6 +106,43 @@ def test_init_with_units():
     assert vov.attrs["units"] == "mm"
 
 
+def test_init_with_offsets():
+    # Test creating VectorOfVectors with offsets parameter
+    offsets = np.array([0, 2, 5, 6, 10, 13], dtype="int64")
+    flattened = Array([1, 2, 3, 4, 5, 2, 4, 8, 9, 7, 5, 3, 1])
+    v = VectorOfVectors(flattened_data=flattened, offsets=offsets)
+
+    assert len(v) == 5
+    assert np.array_equal(v._offsets.nda, offsets)
+    assert np.array_equal(v.cumulative_length.nda, offsets[1:])
+    assert np.array_equal(v[0], [1, 2])
+    assert np.array_equal(v[1], [3, 4, 5])
+    assert np.array_equal(v[2], [2])
+    assert np.array_equal(v[3], [4, 8, 9, 7])
+    assert np.array_equal(v[4], [5, 3, 1])
+
+    # Test that offsets dtype is preserved
+    offsets_u32 = np.array([0, 3, 5], dtype="uint32")
+    flattened_u32 = Array([1, 2, 3, 4, 5])
+    v2 = VectorOfVectors(flattened_data=flattened_u32, offsets=offsets_u32)
+    assert v2._offsets.dtype == np.uint32
+    assert v2.cumulative_length.dtype == np.uint32
+
+    # Test that offsets and cumulative_length are mutually exclusive
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        VectorOfVectors(
+            flattened_data=flattened,
+            offsets=offsets,
+            cumulative_length=Array([2, 5, 6, 10, 13]),
+        )
+
+    # Test view_as uses offsets directly
+    v3 = VectorOfVectors([[1, 2], [3, 4, 5]])
+    ak_arr = v3.view_as("ak")
+    assert ak.is_valid(ak_arr)
+    assert ak_arr.tolist() == [[1, 2], [3, 4, 5]]
+
+
 def test_eq(testvov):
     assert testvov.v2d == VectorOfVectors(
         [[1, 2], [3, 4, 5], [2], [4, 8, 9, 7], [5, 3, 1]]
@@ -152,6 +189,38 @@ def test_serialization(testvov):
     assert isinstance(testvov.v4d.flattened_data, VectorOfVectors)
     assert isinstance(testvov.v4d.flattened_data.flattened_data, VectorOfVectors)
     assert isinstance(testvov.v4d.flattened_data.flattened_data, VectorOfVectors)
+
+    # Test that offsets are correctly stored internally
+    assert np.array_equal(testvov.v2d._offsets.nda, [0, 2, 5, 6, 10, 13])
+    assert np.array_equal(testvov.v3d._offsets.nda, [0, 2, 4, 5])
+
+
+def test_lh5_roundtrip_offsets(tmp_path):
+    """Test that VectorOfVectors round-trips through LH5 without extra copies."""
+    # Create VoV with offsets
+    offsets = np.array([0, 2, 5, 6, 10, 13], dtype="int64")
+    flattened = Array([1, 2, 3, 4, 5, 2, 4, 8, 9, 7, 5, 3, 1])
+    vov = VectorOfVectors(flattened_data=flattened, offsets=offsets)
+
+    # Write and read back
+    fname = tmp_path / "test_vov.lh5"
+    lh5.write(vov, "vov", fname)
+    vov2 = lh5.read("vov", fname)
+
+    # Verify data integrity
+    assert np.array_equal(vov._offsets.nda, vov2._offsets.nda)
+    assert np.array_equal(vov.flattened_data.nda, vov2.flattened_data.nda)
+    assert vov == vov2
+
+    # Test with cumulative_length construction for comparison
+    vov3 = VectorOfVectors(
+        flattened_data=flattened,
+        cumulative_length=Array([2, 5, 6, 10, 13]),
+    )
+    lh5.write(vov3, "vov3", fname, wo_mode="a")
+    vov4 = lh5.read("vov3", fname)
+    assert vov3 == vov4
+    assert np.array_equal(vov3._offsets.nda, vov4._offsets.nda)
 
 
 def test_datatype_name(testvov):


### PR DESCRIPTION
While working on conversion between LGDO tables and PyArrow tables, I stumbled upon [the same off-by-a-leading-zero issue](https://github.com/legend-exp/legend-pydataobj/issues/45) raised by @gipert two years ago. To briefly recap, `pyarrow.ListArray.offsets` (same as `awkward.contents.ListOffsetArray.offsets`) differs from `lgdo.VectorOfVectors.cumulative_length` by a leading zero, and that causes views of a `VectorOfVectors` or tables containing one to allocate.

@iguinn and I discussed storing `offsets` (i.e., `cumulative_length` prepended with a zero) and providing `cumulative_length` as a view of `offsets[1:]`. This PR implements that idea, turning `cumulative_length` into a property that returns a newly created `_OffsetArrayView`, a subclass of `Array`, whose mutating methods are delegated to those of `self._offsets`. This way, the interface to `cumulative_length` remains unbroken.

I have also removed the workaround in `view_as("ak")` mentioned in the issue.
