### PR TITLE
Added ArrayOfDetectorIDs for detectorid types

### DIFF
--- a/src/lgdo/__init__.py
+++ b/src/lgdo/__init__.py
@@ -13,6 +13,8 @@ basic data object classes are:
   :attr:`nda` attribute.
 * :class:`.FixedSizeArray`: basic :class:`numpy.ndarray`. Access data via the
   :attr:`nda` attribute.
+* :class:`.ArrayOfDetectorIDs`: an array of uint32 values encoding the name of a detector
+  in the LEGEND experiment. Access data via the :attr:`nda` attribute.
 * :class:`.ArrayOfEqualSizedArrays`: multi-dimensional :class:`numpy.ndarray`.
   Access data via the :attr:`nda` attribute.
 * :class:`.VectorOfVectors`: an n-dimensional variable length array of variable
@@ -48,6 +50,7 @@ from ._version import version as __version__
 from .types import (
     LGDO,
     Array,
+    ArrayOfDetectorIDs,
     ArrayOfEncodedEqualSizedArrays,
     ArrayOfEqualSizedArrays,
     FixedSizeArray,
@@ -63,6 +66,7 @@ from .types import (
 __all__ = [
     "LGDO",
     "Array",
+    "ArrayOfDetectorIDs",
     "ArrayOfEncodedEqualSizedArrays",
     "ArrayOfEqualSizedArrays",
     "FixedSizeArray",

--- a/src/lgdo/types/__init__.py
+++ b/src/lgdo/types/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .array import Array
+from .arrayofdetectorids import ArrayOfDetectorIDs
 from .arrayofequalsizedarrays import ArrayOfEqualSizedArrays
 from .encoded import ArrayOfEncodedEqualSizedArrays, VectorOfEncodedVectors
 from .fixedsizearray import FixedSizeArray
@@ -17,6 +18,7 @@ from .waveformtable import WaveformTable
 __all__ = [
     "LGDO",
     "Array",
+    "ArrayOfDetectorIDs",
     "ArrayOfEncodedEqualSizedArrays",
     "ArrayOfEqualSizedArrays",
     "FixedSizeArray",

--- a/src/lgdo/types/arrayofdetectorids.py
+++ b/src/lgdo/types/arrayofdetectorids.py
@@ -49,7 +49,8 @@ class ArrayOfDetectorIDs(Array):
         """
 
         if nda is not None and nda.dtype != np.uint32:
-            raise ValueError("ArrayOfDetectorIDs only supports dtype uint32")
+            msg = "ArrayOfDetectorIDs only supports dtype uint32"
+            raise ValueError(msg)
 
         # Force uint32 behavior in superclass initialization.
         super().__init__(

--- a/src/lgdo/types/arrayofdetectorids.py
+++ b/src/lgdo/types/arrayofdetectorids.py
@@ -34,7 +34,7 @@ class ArrayOfDetectorIDs(Array):
         nda
             An :class:`numpy.ndarray` or :class:`ak.Array` to be used for this
             object's internal array. If the Awkward array carries a ``units``
-            parameter, it will forwarded as LGDO attribute.
+            parameter, it will be forwarded as LGDO attribute.
         shape
             A numpy-format shape specification for shape of the internal
             ndarray. Required if `nda` is ``None``, otherwise unused.
@@ -48,14 +48,13 @@ class ArrayOfDetectorIDs(Array):
             carried by `nda`).
         """
 
-        if nda is not None and nda.dtype != np.uint32:
-            msg = "ArrayOfDetectorIDs only supports dtype uint32"
-            raise ValueError(msg)
-
         # Force uint32 behavior in superclass initialization.
         super().__init__(
             nda=nda, shape=shape, dtype=np.uint32, fill_val=fill_val, attrs=attrs
         )
+        if self.dtype != np.uint32:
+            msg = "ArrayOfDetectorIDs only supports dtype uint32"
+            raise ValueError(msg)
 
     def form_datatype(self) -> str:
         dt = self.datatype_name()

--- a/src/lgdo/types/arrayofdetectorids.py
+++ b/src/lgdo/types/arrayofdetectorids.py
@@ -1,0 +1,62 @@
+"""
+Implements a LEGEND Data Object representing an array of detector IDs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import awkward as ak
+import numpy as np
+
+from .array import Array
+
+
+class ArrayOfDetectorIDs(Array):
+    r"""
+    Array of detector IDs, which are uint32 values encoding the name
+    of a detector in the LEGEND experiment. See
+    `Detector ID Encoding <https://legend-exp.github.io/legend-data-format-specs/dev/detector_ids/#Detector-ID-encoding>`_
+    """
+
+    def __init__(
+        self,
+        nda: np.ndarray | ak.Array | None = None,
+        shape: tuple[int, ...] = (),
+        fill_val: int | None = None,
+        attrs: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        See :class:`Array`
+
+        Parameters
+        ----------
+        nda
+            An :class:`numpy.ndarray` or :class:`ak.Array` to be used for this
+            object's internal array. If the Awkward array carries a ``units``
+            parameter, it will forwarded as LGDO attribute.
+        shape
+            A numpy-format shape specification for shape of the internal
+            ndarray. Required if `nda` is ``None``, otherwise unused.
+        fill_val
+            If ``None``, memory is allocated without initialization. Otherwise,
+            the array is allocated with all elements set to the corresponding
+            fill value. If `nda` is not ``None``, this parameter is ignored.
+        attrs
+            A set of user attributes to be carried along with this LGDO. These
+            attributes have always precedence over all the others (e.g. those
+            carried by `nda`).
+        """
+
+        if nda is not None and nda.dtype != np.uint32:
+            raise ValueError("ArrayOfDetectorIDs only supports dtype uint32")
+
+        # Force uint32 behavior in superclass initialization.
+        super().__init__(
+            nda=nda, shape=shape, dtype=np.uint32, fill_val=fill_val, attrs=attrs
+        )
+
+    def form_datatype(self) -> str:
+        dt = self.datatype_name()
+        nd = str(len(self.nda.shape))
+        return dt + "<" + nd + ">{detectorid}"

--- a/src/lgdo/types/vectorofvectors.py
+++ b/src/lgdo/types/vectorofvectors.py
@@ -16,7 +16,6 @@ import pandas as pd
 from numba import jit
 from numpy.typing import ArrayLike, DTypeLike, NDArray
 
-from .. import utils
 from . import arrayofequalsizedarrays as aoesa
 from .array import Array
 from .lgdo import LGDOCollection
@@ -319,12 +318,7 @@ class VectorOfVectors(LGDOCollection):
         return "array"
 
     def form_datatype(self) -> str:
-        eltype = (
-            "array<1>{" + utils.get_element_type(self) + "}"
-            if self.ndim == 2
-            else self.flattened_data.form_datatype()
-        )
-        return "array<1>{" + eltype + "}"
+        return f"array<1>{{{self.flattened_data.form_datatype()}}}"
 
     @property
     def cumulative_length(self) -> Array:

--- a/tests/types/test_arrayofdetectorids.py
+++ b/tests/types/test_arrayofdetectorids.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import awkward as ak
 import numpy as np
 import pytest
 
-from lgdo import ArrayOfDetectorIDs
+from lgdo import ArrayOfDetectorIDs, VectorOfVectors
 
 
 def test_datatype_name():
@@ -20,7 +21,30 @@ def test_form_datatype():
 def test_init():
     attrs = {"attr1": 1}
     with pytest.raises(ValueError):
-        array = ArrayOfDetectorIDs(nda=np.full((3,), 42, np.float32), attrs=attrs)
+        ArrayOfDetectorIDs(nda=np.full((3,), 42, np.float32), attrs=attrs)
     array = ArrayOfDetectorIDs(shape=(3,), fill_val=42, attrs=attrs)
     assert (array.nda == np.full((3,), 42, np.uint32)).all()
     assert array.attrs == attrs | {"datatype": "array<1>{detectorid}"}
+
+    # test 2D array
+    array = ArrayOfDetectorIDs(shape=(3, 4), fill_val=42, attrs=attrs)
+    assert (array.nda == np.full((3, 4), 42, np.uint32)).all()
+    assert array.attrs == attrs | {"datatype": "array<2>{detectorid}"}
+
+    # test VectorOfVectors
+    array = VectorOfVectors(
+        flattened_data=ArrayOfDetectorIDs(shape=(12,), fill_val=42),
+        cumulative_length=np.array([4, 8, 12]),
+        attrs=attrs,
+    )
+    assert (array.flattened_data.nda == np.full((12,), 42, np.uint32)).all()
+    assert (array.cumulative_length.nda == np.array([4, 8, 12])).all
+    assert array.attrs == attrs | {"datatype": "array<1>{array<1>{detectorid}}"}
+
+    # test Awkward array input
+    array = ArrayOfDetectorIDs(
+        nda=ak.with_parameter(np.array([1, 2, 3], dtype=np.uint32), "units", "mm"),
+        attrs=attrs,
+    )
+    assert (array.nda == np.array([1, 2, 3], dtype=np.uint32)).all()
+    assert array.attrs == attrs | {"datatype": "array<1>{detectorid}", "units": "mm"}

--- a/tests/types/test_arrayofdetectorids.py
+++ b/tests/types/test_arrayofdetectorids.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from lgdo import ArrayOfDetectorIDs
+
+
+def test_datatype_name():
+    array = ArrayOfDetectorIDs()
+    assert array.datatype_name() == "array"
+
+
+def test_form_datatype():
+    array = ArrayOfDetectorIDs(shape=(12, 34))
+    assert array.form_datatype() == "array<2>{detectorid}"
+    assert array.dtype == np.uint32
+
+
+def test_init():
+    attrs = {"attr1": 1}
+    with pytest.raises(ValueError):
+        array = ArrayOfDetectorIDs(nda=np.full((3,), 42, np.float32), attrs=attrs)
+    array = ArrayOfDetectorIDs(shape=(3,), fill_val=42, attrs=attrs)
+    assert (array.nda == np.full((3,), 42, np.uint32)).all()
+    assert array.attrs == attrs | {"datatype": "array<1>{detectorid}"}


### PR DESCRIPTION
See https://github.com/legend-exp/legend-pydataobj/issues/218

Currently ArrayOfDetectorIDs simply inherits Array, enforces dtype = unit32, and uses detectorid in the typestring.