### PR TITLE
View LGDO tables as PyArrow tables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "parse",
     "pint>0.24",
     "pint-pandas",
+    "pyarrow",
 ]
 dynamic = [
     "version",
@@ -59,10 +60,7 @@ write_to = "src/lgdo/_version.py"
 
 [project.optional-dependencies]
 all = [
-    "legend-pydataobj[docs,test,arrow]",
-]
-arrow = [
-    "pyarrow",
+    "legend-pydataobj[docs,test]",
 ]
 docs = [
     "furo",
@@ -80,7 +78,6 @@ test = [
     "pytest-cov",
     "h5py",
     "dbetto",
-    "pyarrow",
 ]
 
 [tool.setuptools]
@@ -136,6 +133,7 @@ ignore = [
   "ISC001",   # Conflicts with formatter
   "PT011",
   "RUF013",   # complains if you default to None for an asinine reason
+  "PLC0415",  # deferred imports used to break circular deps
 ]
 isort.required-imports = ["from __future__ import annotations"]
 # Uncomment if using a _compat.typing backport

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,10 @@ write_to = "src/lgdo/_version.py"
 
 [project.optional-dependencies]
 all = [
-    "legend-pydataobj[docs,test]",
+    "legend-pydataobj[docs,test,arrow]",
+]
+arrow = [
+    "pyarrow",
 ]
 docs = [
     "furo",
@@ -76,7 +79,8 @@ test = [
     "pytest>=6.0",
     "pytest-cov",
     "h5py",
-    "dbetto"
+    "dbetto",
+    "pyarrow",
 ]
 
 [tool.setuptools]

--- a/src/lgdo/types/array.py
+++ b/src/lgdo/types/array.py
@@ -14,6 +14,7 @@ import awkward_pandas as akpd
 import numpy as np
 import pandas as pd
 import pint_pandas  # noqa: F401
+import pyarrow as pa
 
 from .. import utils
 from ..units import default_units_registry as u
@@ -111,9 +112,8 @@ class Array(LGDOCollection):
         elif isinstance(nda, Array):
             nda = nda.nda
 
-        elif getattr(type(nda), "__module__", "").startswith("pyarrow"):
+        elif isinstance(nda, (pa.Array, pa.ChunkedArray)):
             from .arrow import arrow_to_lgdo
-
             converted = arrow_to_lgdo(nda)
             nda = converted.nda
             if attrs is None:
@@ -327,7 +327,6 @@ class Array(LGDOCollection):
 
         if library == "arrow":
             from .arrow import lgdo_to_arrow
-
             return lgdo_to_arrow(self)
 
         msg = f"{library} is not a supported third-party format."

--- a/src/lgdo/types/array.py
+++ b/src/lgdo/types/array.py
@@ -114,6 +114,7 @@ class Array(LGDOCollection):
 
         elif isinstance(nda, (pa.Array, pa.ChunkedArray)):
             from .arrow import arrow_to_lgdo
+
             converted = arrow_to_lgdo(nda)
             nda = converted.nda
             if attrs is None:
@@ -327,6 +328,7 @@ class Array(LGDOCollection):
 
         if library == "arrow":
             from .arrow import lgdo_to_arrow
+
             return lgdo_to_arrow(self)
 
         msg = f"{library} is not a supported third-party format."

--- a/src/lgdo/types/array.py
+++ b/src/lgdo/types/array.py
@@ -111,6 +111,14 @@ class Array(LGDOCollection):
         elif isinstance(nda, Array):
             nda = nda.nda
 
+        elif getattr(type(nda), "__module__", "").startswith("pyarrow"):
+            from .arrow import arrow_to_lgdo
+
+            converted = arrow_to_lgdo(nda)
+            nda = converted.nda
+            if attrs is None:
+                attrs = converted.getattrs()
+
         self.nda = nda
 
         super().__init__(attrs)
@@ -316,6 +324,11 @@ class Array(LGDOCollection):
                 ak_arr = ak.with_parameter(ak_arr, "units", self.attrs["units"])
 
             return ak_arr
+
+        if library == "arrow":
+            from .arrow import lgdo_to_arrow
+
+            return lgdo_to_arrow(self)
 
         msg = f"{library} is not a supported third-party format."
         raise ValueError(msg)

--- a/src/lgdo/types/arrayofequalsizedarrays.py
+++ b/src/lgdo/types/arrayofequalsizedarrays.py
@@ -69,6 +69,7 @@ class ArrayOfEqualSizedArrays(Array):
         """
         if isinstance(nda, (pa.Array, pa.ChunkedArray)):
             from .arrow import arrow_to_lgdo
+
             converted = arrow_to_lgdo(nda)
             nda = converted.nda
             if attrs is None and converted.getattrs():
@@ -156,6 +157,7 @@ class ArrayOfEqualSizedArrays(Array):
         """
         if library == "arrow":
             from .arrow import lgdo_to_arrow
+
             return lgdo_to_arrow(self)
 
         return super().view_as(library, with_units=with_units)

--- a/src/lgdo/types/arrayofequalsizedarrays.py
+++ b/src/lgdo/types/arrayofequalsizedarrays.py
@@ -11,6 +11,7 @@ from typing import Any
 import awkward as ak
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 
 from .. import utils
 from . import vectorofvectors as vov
@@ -66,11 +67,8 @@ class ArrayOfEqualSizedArrays(Array):
         --------
         :class:`.Array`
         """
-        if nda is not None and getattr(type(nda), "__module__", "").startswith(
-            "pyarrow"
-        ):
+        if isinstance(nda, (pa.Array, pa.ChunkedArray)):
             from .arrow import arrow_to_lgdo
-
             converted = arrow_to_lgdo(nda)
             nda = converted.nda
             if attrs is None and converted.getattrs():
@@ -158,7 +156,6 @@ class ArrayOfEqualSizedArrays(Array):
         """
         if library == "arrow":
             from .arrow import lgdo_to_arrow
-
             return lgdo_to_arrow(self)
 
         return super().view_as(library, with_units=with_units)

--- a/src/lgdo/types/arrayofequalsizedarrays.py
+++ b/src/lgdo/types/arrayofequalsizedarrays.py
@@ -66,6 +66,16 @@ class ArrayOfEqualSizedArrays(Array):
         --------
         :class:`.Array`
         """
+        if nda is not None and getattr(type(nda), "__module__", "").startswith(
+            "pyarrow"
+        ):
+            from .arrow import arrow_to_lgdo
+
+            converted = arrow_to_lgdo(nda)
+            nda = converted.nda
+            if attrs is None and converted.getattrs():
+                attrs = converted.getattrs()
+
         if dims is None:
             # If no dims are provided, assume that it's a 1D Array of (N-1)-D Arrays
             if nda is None:
@@ -146,4 +156,9 @@ class ArrayOfEqualSizedArrays(Array):
         --------
         .LGDO.view_as
         """
+        if library == "arrow":
+            from .arrow import lgdo_to_arrow
+
+            return lgdo_to_arrow(self)
+
         return super().view_as(library, with_units=with_units)

--- a/src/lgdo/types/arrow.py
+++ b/src/lgdo/types/arrow.py
@@ -1,0 +1,234 @@
+"""Zero-copy conversion between LGDO and Arrow types.
+
+Note on allocation: we use ``to_numpy(zero_copy_only=False)`` throughout.
+PyArrow performs zero-copy for all numeric types and only allocates when it
+must (e.g. booleans, which are bit-packed in Arrow but byte-packed in NumPy,
+or columns containing nulls that need sentinel values). Multi-chunk columns
+are combined automatically with a warning.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+
+import numpy as np
+import pyarrow as pa
+
+from .array import Array
+from .arrayofequalsizedarrays import ArrayOfEqualSizedArrays
+from .table import Table
+from .vectorofvectors import VectorOfVectors
+from .waveformtable import WaveformTable
+
+# ============ Attrs serialization ============
+
+
+def _serialize_attr(value) -> str:
+    """Serialize an attr value to a JSON string for Arrow metadata."""
+    try:
+        return json.dumps(value)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _deserialize_attr(raw: bytes):
+    """Deserialize an Arrow metadata value back to a Python object."""
+    s = raw.decode()
+    try:
+        return json.loads(s)
+    except (json.JSONDecodeError, ValueError):
+        return s
+
+
+# ============ LGDO → Arrow ============
+
+
+def lgdo_to_arrow(obj) -> pa.Table | pa.Array:
+    """Convert an LGDO object to its Arrow equivalent.
+
+    Type mapping:
+
+    ========================  ==========================
+    LGDO type                 Arrow type
+    ========================  ==========================
+    Table                     pa.Table
+    WaveformTable             pa.StructArray
+    Array                     pa.Array
+    ArrayOfEqualSizedArrays   pa.FixedSizeListArray
+    VectorOfVectors           pa.ListArray
+    ========================  ==========================
+
+    Preserves all attrs as JSON-encoded Arrow field metadata.
+
+    Parameters
+    ----------
+    obj
+        Any supported LGDO object.
+
+    Returns
+    -------
+    pa.Table or pa.Array
+        Arrow table (for Table) or Arrow array (for all other types).
+    """
+    if isinstance(obj, Table) and not isinstance(obj, WaveformTable):
+        struct_arr = _lgdo_col_to_arrow(obj)
+        return pa.Table.from_batches([pa.RecordBatch.from_struct_array(struct_arr)])
+    return _lgdo_col_to_arrow(obj)
+
+
+def _lgdo_col_to_arrow(col) -> pa.Array:
+    """Convert single LGDO column to Arrow array.
+
+    Tables (including WaveformTable) become StructArrays with child field
+    metadata preserving attrs like units.
+    """
+    if isinstance(col, Table):
+        child_arrays = []
+        child_fields = []
+        for name, sub_col in col.items():
+            child_arr = _lgdo_col_to_arrow(sub_col)
+            meta = None
+            if hasattr(sub_col, "attrs") and sub_col.attrs:
+                meta = {k: _serialize_attr(v) for k, v in sub_col.attrs.items()}
+            child_fields.append(pa.field(name, child_arr.type, metadata=meta))
+            child_arrays.append(child_arr)
+        return pa.StructArray.from_arrays(child_arrays, fields=child_fields)
+
+    if isinstance(col, ArrayOfEqualSizedArrays):
+        arr = pa.array(col.nda.ravel())
+        for dim in reversed(col.nda.shape[1:]):
+            arr = pa.FixedSizeListArray.from_arrays(arr, dim)
+        return arr
+
+    if isinstance(col, VectorOfVectors):
+        return pa.ListArray.from_arrays(
+            col._offsets.nda, _lgdo_col_to_arrow(col.flattened_data)
+        )
+
+    if isinstance(col, Array):
+        return pa.array(col.nda)
+
+    msg = f"Unsupported LGDO type: {type(col)}"
+    raise TypeError(msg)
+
+
+# ============ Arrow → LGDO ============
+
+
+def arrow_to_lgdo(obj):
+    """Convert an Arrow object to its LGDO equivalent.
+
+    Type mapping:
+
+    ==================================  ==========================
+    Arrow type                          LGDO type
+    ==================================  ==========================
+    pa.Table                            Table
+    StructArray with {t0, dt, values}   WaveformTable
+    StructArray (other)                 Table
+    FixedSizeListArray                  ArrayOfEqualSizedArrays
+    ListArray                           VectorOfVectors
+    primitive Array                     Array
+    ==================================  ==========================
+
+    Zero-copy where possible. Multi-chunk columns are combined
+    automatically (with a warning, since this allocates).
+
+    Parameters
+    ----------
+    obj
+        Any supported Arrow object.
+
+    Returns
+    -------
+    Table, WaveformTable, Array, ArrayOfEqualSizedArrays, or VectorOfVectors
+    """
+    if isinstance(obj, pa.Table):
+        col_dict = {}
+        for name in obj.column_names:
+            field = obj.schema.field(name)
+            col = obj.column(name)
+            if col.num_chunks != 1:
+                warnings.warn(
+                    f"Column '{name}' has {col.num_chunks} chunks; "
+                    "combining into one contiguous buffer (allocates memory)",
+                    stacklevel=2,
+                )
+            col_dict[name] = _arrow_col_to_lgdo(col.combine_chunks(), field)
+        return Table(col_dict=col_dict)
+
+    if isinstance(obj, pa.ChunkedArray):
+        if obj.num_chunks != 1:
+            warnings.warn(
+                f"ChunkedArray has {obj.num_chunks} chunks; "
+                "combining into one contiguous buffer (allocates memory)",
+                stacklevel=2,
+            )
+        return _arrow_col_to_lgdo(obj.combine_chunks(), None)
+
+    return _arrow_col_to_lgdo(obj, None)
+
+
+def _arrow_col_to_lgdo(col: pa.Array, field: pa.Field | None):
+    """Convert Arrow array to LGDO column (zero-copy).
+
+    StructArrays whose fields are {t0, dt, values} become WaveformTables;
+    other StructArrays become plain Tables.
+    """
+    attrs = (
+        {k.decode(): _deserialize_attr(v) for k, v in field.metadata.items()}
+        if field and field.metadata
+        else None
+    )
+
+    if isinstance(col.type, pa.StructType):
+        col_dict = {}
+        for i in range(col.type.num_fields):
+            sub_field = col.type.field(i)
+            col_dict[sub_field.name] = _arrow_col_to_lgdo(
+                col.field(sub_field.name), sub_field
+            )
+
+        if col_dict.keys() == {"t0", "dt", "values"}:
+            # t0 and dt need to be writable as required by dspeed.build_processing_chain
+            t0 = col_dict["t0"]
+            dt = col_dict["dt"]
+            return WaveformTable(
+                t0=Array(nda=np.array(t0.nda, copy=True), attrs=t0.attrs),
+                dt=Array(nda=np.array(dt.nda, copy=True), attrs=dt.attrs),
+                values=col_dict["values"],
+                attrs=attrs,
+            )
+
+        return Table(col_dict=col_dict, attrs=attrs)
+
+    if isinstance(col.type, pa.FixedSizeListType):
+        return ArrayOfEqualSizedArrays(
+            nda=_nested_fixed_list_to_nda(col), attrs=attrs
+        )
+
+    if isinstance(col.type, pa.ListType):
+        offsets = col.offsets.to_numpy(zero_copy_only=True, writable=False)
+
+        if isinstance(
+            col.values.type, (pa.ListType, pa.FixedSizeListType, pa.StructType)
+        ):
+            flattened = _arrow_col_to_lgdo(col.values, None)
+        else:
+            flattened = col.values.to_numpy(zero_copy_only=False, writable=False)
+
+        return VectorOfVectors(
+            flattened_data=flattened, offsets=offsets, attrs=attrs
+        )
+
+    return Array(nda=col.to_numpy(zero_copy_only=False, writable=False), attrs=attrs)
+
+
+def _nested_fixed_list_to_nda(arr: pa.Array) -> np.ndarray:
+    """Convert nested Arrow fixed_size_list to N-D numpy array."""
+    dims = []
+    while isinstance(arr.type, pa.FixedSizeListType):
+        dims.append(arr.type.list_size)
+        arr = arr.values
+    return arr.to_numpy(zero_copy_only=False, writable=False).reshape(-1, *dims)

--- a/src/lgdo/types/arrow.py
+++ b/src/lgdo/types/arrow.py
@@ -204,9 +204,7 @@ def _arrow_col_to_lgdo(col: pa.Array, field: pa.Field | None):
         return Table(col_dict=col_dict, attrs=attrs)
 
     if isinstance(col.type, pa.FixedSizeListType):
-        return ArrayOfEqualSizedArrays(
-            nda=_nested_fixed_list_to_nda(col), attrs=attrs
-        )
+        return ArrayOfEqualSizedArrays(nda=_nested_fixed_list_to_nda(col), attrs=attrs)
 
     if isinstance(col.type, pa.ListType):
         offsets = col.offsets.to_numpy(zero_copy_only=True, writable=False)
@@ -218,9 +216,7 @@ def _arrow_col_to_lgdo(col: pa.Array, field: pa.Field | None):
         else:
             flattened = col.values.to_numpy(zero_copy_only=False, writable=False)
 
-        return VectorOfVectors(
-            flattened_data=flattened, offsets=offsets, attrs=attrs
-        )
+        return VectorOfVectors(flattened_data=flattened, offsets=offsets, attrs=attrs)
 
     return Array(nda=col.to_numpy(zero_copy_only=False, writable=False), attrs=attrs)
 

--- a/src/lgdo/types/arrow.py
+++ b/src/lgdo/types/arrow.py
@@ -73,7 +73,11 @@ def lgdo_to_arrow(obj) -> pa.Table | pa.Array:
     """
     if isinstance(obj, Table) and not isinstance(obj, WaveformTable):
         struct_arr = _lgdo_col_to_arrow(obj)
-        return pa.Table.from_batches([pa.RecordBatch.from_struct_array(struct_arr)])
+        table = pa.Table.from_batches([pa.RecordBatch.from_struct_array(struct_arr)])
+        if obj.attrs:
+            meta = {k: _serialize_attr(v) for k, v in obj.attrs.items()}
+            table = table.replace_schema_metadata(meta)
+        return table
     return _lgdo_col_to_arrow(obj)
 
 
@@ -156,7 +160,12 @@ def arrow_to_lgdo(obj):
                     stacklevel=2,
                 )
             col_dict[name] = _arrow_col_to_lgdo(col.combine_chunks(), field)
-        return Table(col_dict=col_dict)
+        attrs = (
+            {k.decode(): _deserialize_attr(v) for k, v in obj.schema.metadata.items()}
+            if obj.schema.metadata
+            else None
+        )
+        return Table(col_dict=col_dict, attrs=attrs)
 
     if isinstance(obj, pa.ChunkedArray):
         if obj.num_chunks != 1:

--- a/src/lgdo/types/lgdo.py
+++ b/src/lgdo/types/lgdo.py
@@ -58,10 +58,20 @@ class LGDO(ABC):
         - ``pd``: :mod:`pandas`
         - ``np``: :mod:`numpy`
         - ``ak``: :mod:`awkward`
+        - ``arrow``: :mod:`pyarrow`
 
         Note
         ----
         Awkward does not support attaching units through Pint, at the moment.
+
+        Note
+        ----
+        The ``arrow`` format uses zero-copy for numeric arrays. Booleans
+        (bit-packed in Arrow, byte-packed in NumPy) and null-containing columns
+        require allocation. WaveformTable ``t0`` and ``dt`` arrays are copied
+        to ensure writability, as required by
+        :func:`dspeed.build_processing_chain`. All attrs are preserved as
+        JSON-encoded Arrow field metadata.
 
         but the actual supported formats may vary depending on the concrete
         LGDO class.

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -89,6 +89,14 @@ class Table(Struct, LGDOCollection):
         if isinstance(col_dict, ak.Array):
             col_dict = _ak_to_lgdo_or_col_dict(col_dict)
 
+        if getattr(type(col_dict), "__module__", "").startswith("pyarrow"):
+            from .arrow import arrow_to_lgdo
+
+            converted = arrow_to_lgdo(col_dict)
+            col_dict = dict(converted.items())
+            if attrs is None and converted.getattrs():
+                attrs = converted.getattrs()
+
         # call Struct constructor
         Struct.__init__(self, obj_dict=col_dict, attrs=attrs)
         # no need to call the LGDOCollection constructor, as we are calling the
@@ -646,6 +654,11 @@ class Table(Struct, LGDOCollection):
             return ak.Array(
                 {col: self[col].view_as("ak", with_units=with_units) for col in cols}
             )
+
+        if library == "arrow":
+            from .arrow import lgdo_to_arrow
+
+            return lgdo_to_arrow(self)
 
         msg = f"{library!r} is not a supported third-party format."
         raise TypeError(msg)

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -659,7 +659,10 @@ class Table(Struct, LGDOCollection):
         if library == "arrow":
             from .arrow import lgdo_to_arrow
 
-            return lgdo_to_arrow(self)
+            table = lgdo_to_arrow(self)
+            if list(cols) != list(self.keys()):
+                table = table.select(list(cols))
+            return table
 
         msg = f"{library!r} is not a supported third-party format."
         raise TypeError(msg)

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -92,6 +92,7 @@ class Table(Struct, LGDOCollection):
 
         if isinstance(col_dict, pa.Table):
             from .arrow import arrow_to_lgdo
+
             converted = arrow_to_lgdo(col_dict)
             col_dict = dict(converted.items())
             if attrs is None and converted.getattrs():
@@ -657,6 +658,7 @@ class Table(Struct, LGDOCollection):
 
         if library == "arrow":
             from .arrow import lgdo_to_arrow
+
             return lgdo_to_arrow(self)
 
         msg = f"{library!r} is not a supported third-party format."

--- a/src/lgdo/types/table.py
+++ b/src/lgdo/types/table.py
@@ -15,6 +15,7 @@ import awkward as ak
 import numexpr as ne
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 from pandas.io.formats import format as fmt
 
 import lgdo
@@ -89,9 +90,8 @@ class Table(Struct, LGDOCollection):
         if isinstance(col_dict, ak.Array):
             col_dict = _ak_to_lgdo_or_col_dict(col_dict)
 
-        if getattr(type(col_dict), "__module__", "").startswith("pyarrow"):
+        if isinstance(col_dict, pa.Table):
             from .arrow import arrow_to_lgdo
-
             converted = arrow_to_lgdo(col_dict)
             col_dict = dict(converted.items())
             if attrs is None and converted.getattrs():
@@ -657,7 +657,6 @@ class Table(Struct, LGDOCollection):
 
         if library == "arrow":
             from .arrow import lgdo_to_arrow
-
             return lgdo_to_arrow(self)
 
         msg = f"{library!r} is not a supported third-party format."

--- a/src/lgdo/types/vectorofvectors.py
+++ b/src/lgdo/types/vectorofvectors.py
@@ -154,6 +154,7 @@ class VectorOfVectors(LGDOCollection):
 
         if isinstance(data, (pa.Array, pa.ChunkedArray)):
             from .arrow import arrow_to_lgdo
+
             converted = arrow_to_lgdo(data)
             data = None
             flattened_data = converted.flattened_data
@@ -612,6 +613,7 @@ class VectorOfVectors(LGDOCollection):
             else:
                 nan_val = np.nan
             from .vovutils import _nb_fill
+
             self.flattened_data.resize(cum_lens[-1])
             self.cumulative_length.resize(i + len(lens))
 
@@ -860,6 +862,7 @@ class VectorOfVectors(LGDOCollection):
 
         if library == "arrow":
             from .arrow import lgdo_to_arrow
+
             return lgdo_to_arrow(self)
 
         msg = f"{library} is not a supported third-party format."

--- a/src/lgdo/types/vectorofvectors.py
+++ b/src/lgdo/types/vectorofvectors.py
@@ -151,6 +151,18 @@ class VectorOfVectors(LGDOCollection):
         ):
             flattened_data = Array(flattened_data)
 
+        if data is not None and getattr(type(data), "__module__", "").startswith(
+            "pyarrow"
+        ):
+            from .arrow import arrow_to_lgdo
+
+            converted = arrow_to_lgdo(data)
+            data = None
+            flattened_data = converted.flattened_data
+            offsets = converted._offsets
+            if attrs is None and converted.getattrs():
+                attrs = converted.getattrs()
+
         if data is not None:
             if not isinstance(data, ak.Array):
                 data = ak.Array(data)
@@ -848,6 +860,11 @@ class VectorOfVectors(LGDOCollection):
                 raise ValueError(msg)
 
             return akpd.from_awkward(self.view_as("ak"))
+
+        if library == "arrow":
+            from .arrow import lgdo_to_arrow
+
+            return lgdo_to_arrow(self)
 
         msg = f"{library} is not a supported third-party format."
         raise ValueError(msg)

--- a/src/lgdo/types/vectorofvectors.py
+++ b/src/lgdo/types/vectorofvectors.py
@@ -13,6 +13,7 @@ import awkward as ak
 import awkward_pandas as akpd
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 from numba import jit
 from numpy.typing import ArrayLike, DTypeLike, NDArray
 
@@ -151,11 +152,8 @@ class VectorOfVectors(LGDOCollection):
         ):
             flattened_data = Array(flattened_data)
 
-        if data is not None and getattr(type(data), "__module__", "").startswith(
-            "pyarrow"
-        ):
+        if isinstance(data, (pa.Array, pa.ChunkedArray)):
             from .arrow import arrow_to_lgdo
-
             converted = arrow_to_lgdo(data)
             data = None
             flattened_data = converted.flattened_data
@@ -613,8 +611,7 @@ class VectorOfVectors(LGDOCollection):
                 nan_val = np.iinfo(self.flattened_data.dtype).min
             else:
                 nan_val = np.nan
-            from .vovutils import _nb_fill  # noqa: PLC0415
-
+            from .vovutils import _nb_fill
             self.flattened_data.resize(cum_lens[-1])
             self.cumulative_length.resize(i + len(lens))
 
@@ -863,7 +860,6 @@ class VectorOfVectors(LGDOCollection):
 
         if library == "arrow":
             from .arrow import lgdo_to_arrow
-
             return lgdo_to_arrow(self)
 
         msg = f"{library} is not a supported third-party format."

--- a/src/lgdo/types/vectorofvectors.py
+++ b/src/lgdo/types/vectorofvectors.py
@@ -152,7 +152,11 @@ class VectorOfVectors(LGDOCollection):
         ):
             flattened_data = Array(flattened_data)
 
-        if isinstance(data, (pa.Array, pa.ChunkedArray)):
+        if isinstance(data, pa.ListArray) or (
+            isinstance(data, pa.ChunkedArray)
+            and isinstance(data.type.value_type, pa.DataType)
+            and pa.types.is_list(data.type)
+        ):
             from .arrow import arrow_to_lgdo
 
             converted = arrow_to_lgdo(data)

--- a/src/lgdo/types/waveformtable.py
+++ b/src/lgdo/types/waveformtable.py
@@ -279,7 +279,6 @@ class WaveformTable(Table):
         """
         if library == "arrow":
             from .arrow import lgdo_to_arrow
-
             return lgdo_to_arrow(self)
 
         return super().view_as(library, with_units, cols, prefix)

--- a/src/lgdo/types/waveformtable.py
+++ b/src/lgdo/types/waveformtable.py
@@ -277,4 +277,9 @@ class WaveformTable(Table):
         --------
         .LGDO.view_as
         """
+        if library == "arrow":
+            from .arrow import lgdo_to_arrow
+
+            return lgdo_to_arrow(self)
+
         return super().view_as(library, with_units, cols, prefix)

--- a/src/lgdo/types/waveformtable.py
+++ b/src/lgdo/types/waveformtable.py
@@ -279,6 +279,7 @@ class WaveformTable(Table):
         """
         if library == "arrow":
             from .arrow import lgdo_to_arrow
+
             return lgdo_to_arrow(self)
 
         return super().view_as(library, with_units, cols, prefix)

--- a/tests/types/test_arrow.py
+++ b/tests/types/test_arrow.py
@@ -1,0 +1,312 @@
+"""Tests for Arrow conversion integration."""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+pa = pytest.importorskip("pyarrow")
+
+from lgdo import Array, ArrayOfEqualSizedArrays, Table, VectorOfVectors  # noqa: E402
+from lgdo.types.arrow import arrow_to_lgdo, lgdo_to_arrow  # noqa: E402
+from lgdo.types.waveformtable import WaveformTable  # noqa: E402
+
+# ============ Helpers ============
+
+
+def _make_waveform_table():
+    return WaveformTable(
+        t0=Array(nda=np.array([0.0, 0.1]), attrs={"units": "us"}),
+        dt=Array(nda=np.array([16.0, 16.0]), attrs={"units": "ns"}),
+        values=ArrayOfEqualSizedArrays(
+            nda=np.arange(10, dtype=np.float32).reshape(2, 5)
+        ),
+    )
+
+
+# ============ lgdo_to_arrow output types ============
+
+
+class TestLgdoToArrowTypes:
+    def test_table_returns_pa_table(self):
+        tbl = Table(col_dict={"x": Array(nda=np.array([1, 2]))})
+        assert isinstance(lgdo_to_arrow(tbl), pa.Table)
+
+    def test_waveformtable_returns_struct_array(self):
+        result = lgdo_to_arrow(_make_waveform_table())
+        assert isinstance(result, pa.StructArray)
+
+    def test_array_returns_pa_array(self):
+        result = lgdo_to_arrow(Array(nda=np.array([1.0, 2.0])))
+        assert isinstance(result, pa.Array)
+        assert not isinstance(result, pa.StructArray)
+
+    def test_aoesa_returns_fixed_size_list(self):
+        result = lgdo_to_arrow(ArrayOfEqualSizedArrays(nda=np.zeros((3, 4))))
+        assert isinstance(result.type, pa.FixedSizeListType)
+
+    def test_vov_returns_list_array(self):
+        vov = VectorOfVectors(
+            flattened_data=np.array([1, 2, 3]),
+            offsets=np.array([0, 2, 3]),
+        )
+        assert isinstance(lgdo_to_arrow(vov), pa.ListArray)
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(TypeError, match="Unsupported LGDO type"):
+            lgdo_to_arrow("not an lgdo object")
+
+
+# ============ arrow_to_lgdo output types ============
+
+
+class TestArrowToLgdoTypes:
+    def test_pa_table_returns_table(self):
+        tbl = pa.table({"x": [1, 2, 3]})
+        assert isinstance(arrow_to_lgdo(tbl), Table)
+
+    def test_struct_with_waveform_fields_returns_waveformtable(self):
+        struct = lgdo_to_arrow(_make_waveform_table())
+        assert isinstance(arrow_to_lgdo(struct), WaveformTable)
+
+    def test_struct_without_waveform_fields_returns_table(self):
+        struct = pa.StructArray.from_arrays(
+            [pa.array([1, 2]), pa.array([3, 4])],
+            names=["a", "b"],
+        )
+        result = arrow_to_lgdo(struct)
+        assert isinstance(result, Table)
+        assert not isinstance(result, WaveformTable)
+
+    def test_fixed_size_list_returns_aoesa(self):
+        arr = pa.FixedSizeListArray.from_arrays(pa.array(np.arange(12)), 4)
+        assert isinstance(arrow_to_lgdo(arr), ArrayOfEqualSizedArrays)
+
+    def test_list_array_returns_vov(self):
+        arr = pa.ListArray.from_arrays(
+            pa.array([0, 2, 3, 5]),
+            pa.array([1, 2, 3, 4, 5]),
+        )
+        assert isinstance(arrow_to_lgdo(arr), VectorOfVectors)
+
+    def test_primitive_array_returns_array(self):
+        assert isinstance(arrow_to_lgdo(pa.array([1, 2, 3])), Array)
+
+    def test_chunked_array_warns(self):
+        chunked = pa.chunked_array([pa.array([1, 2]), pa.array([3, 4])])
+        with pytest.warns(UserWarning, match="2 chunks"):
+            result = arrow_to_lgdo(chunked)
+        assert isinstance(result, Array)
+        assert_array_equal(result.nda, [1, 2, 3, 4])
+
+    def test_single_chunk_no_warning(self):
+        chunked = pa.chunked_array([pa.array([1, 2, 3])])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            result = arrow_to_lgdo(chunked)
+        assert isinstance(result, Array)
+
+
+# ============ Round-trip data integrity ============
+
+
+class TestRoundTrip:
+    def test_array(self):
+        original = Array(nda=np.array([1.5, 2.5, 3.5]))
+        back = arrow_to_lgdo(lgdo_to_arrow(original))
+        assert isinstance(back, Array)
+        assert_array_equal(back.nda, original.nda)
+
+    def test_array_int(self):
+        original = Array(nda=np.array([10, 20, 30], dtype=np.int32))
+        back = arrow_to_lgdo(lgdo_to_arrow(original))
+        assert_array_equal(back.nda, original.nda)
+        assert back.nda.dtype == np.int32
+
+    def test_aoesa_2d(self):
+        original = ArrayOfEqualSizedArrays(nda=np.arange(12).reshape(3, 4))
+        back = arrow_to_lgdo(lgdo_to_arrow(original))
+        assert isinstance(back, ArrayOfEqualSizedArrays)
+        assert_array_equal(back.nda, original.nda)
+
+    def test_aoesa_3d(self):
+        original = ArrayOfEqualSizedArrays(nda=np.arange(24).reshape(2, 3, 4))
+        back = arrow_to_lgdo(lgdo_to_arrow(original))
+        assert_array_equal(back.nda, original.nda)
+
+    def test_vov(self):
+        flat = np.array([10, 20, 30, 40, 50])
+        offsets = np.array([0, 2, 3, 5])
+        original = VectorOfVectors(flattened_data=flat, offsets=offsets)
+        back = arrow_to_lgdo(lgdo_to_arrow(original))
+        assert isinstance(back, VectorOfVectors)
+        assert_array_equal(back.flattened_data, flat)
+        assert_array_equal(back._offsets.nda, offsets)
+
+    def test_vov_with_aoesa_flattened_data(self):
+        aoesa = ArrayOfEqualSizedArrays(nda=np.arange(20).reshape(5, 4))
+        original = VectorOfVectors(flattened_data=aoesa, offsets=np.array([0, 2, 5]))
+        back = arrow_to_lgdo(lgdo_to_arrow(original))
+        assert isinstance(back, VectorOfVectors)
+        assert isinstance(back.flattened_data, ArrayOfEqualSizedArrays)
+        assert_array_equal(back.flattened_data.nda, aoesa.nda)
+
+    def test_nested_vov(self):
+        inner = VectorOfVectors(
+            flattened_data=np.array([1, 2, 3, 4, 5, 6]),
+            offsets=np.array([0, 2, 3, 6]),
+        )
+        original = VectorOfVectors(flattened_data=inner, offsets=np.array([0, 1, 3]))
+        back = arrow_to_lgdo(lgdo_to_arrow(original))
+        assert isinstance(back, VectorOfVectors)
+        assert isinstance(back.flattened_data, VectorOfVectors)
+
+    def test_table(self):
+        original = Table(
+            col_dict={
+                "energy": Array(nda=np.array([1.0, 2.0, 3.0])),
+                "channel": Array(nda=np.array([0, 1, 2])),
+            }
+        )
+        back = arrow_to_lgdo(lgdo_to_arrow(original))
+        assert isinstance(back, Table)
+        assert_array_equal(back["energy"].nda, original["energy"].nda)
+        assert_array_equal(back["channel"].nda, original["channel"].nda)
+
+    def test_waveform_table(self):
+        original = _make_waveform_table()
+        back = arrow_to_lgdo(lgdo_to_arrow(original))
+        assert isinstance(back, WaveformTable)
+        assert_array_equal(back["t0"].nda, original["t0"].nda)
+        assert_array_equal(back["dt"].nda, original["dt"].nda)
+        assert_array_equal(back["values"].nda, original["values"].nda)
+
+    def test_table_with_nested_waveform(self):
+        original = Table(
+            col_dict={
+                "energy": Array(nda=np.array([1.0, 2.0])),
+                "waveform": _make_waveform_table(),
+            }
+        )
+        back = arrow_to_lgdo(lgdo_to_arrow(original))
+        assert isinstance(back["waveform"], WaveformTable)
+        assert_array_equal(
+            back["waveform"]["values"].nda,
+            original["waveform"]["values"].nda,
+        )
+
+
+# ============ Attrs round-trip ============
+
+
+class TestAttrsRoundTrip:
+    def test_string_attr(self):
+        tbl = Table(
+            col_dict={"x": Array(nda=np.array([1.0]), attrs={"units": "keV"})}
+        )
+        back = arrow_to_lgdo(lgdo_to_arrow(tbl))
+        assert back["x"].attrs["units"] == "keV"
+
+    def test_numeric_attr(self):
+        tbl = Table(
+            col_dict={
+                "x": Array(nda=np.array([1.0]), attrs={"version": 3, "scale": 1.5})
+            }
+        )
+        back = arrow_to_lgdo(lgdo_to_arrow(tbl))
+        assert back["x"].attrs["version"] == 3
+        assert isinstance(back["x"].attrs["version"], int)
+        assert back["x"].attrs["scale"] == 1.5
+
+    def test_bool_attr(self):
+        tbl = Table(
+            col_dict={
+                "x": Array(nda=np.array([1.0]), attrs={"calibrated": True})
+            }
+        )
+        back = arrow_to_lgdo(lgdo_to_arrow(tbl))
+        assert back["x"].attrs["calibrated"] is True
+
+    def test_dict_attr(self):
+        tbl = Table(
+            col_dict={
+                "x": Array(nda=np.array([1.0]), attrs={"info": {"a": 1, "b": 2}})
+            }
+        )
+        back = arrow_to_lgdo(lgdo_to_arrow(tbl))
+        assert back["x"].attrs["info"] == {"a": 1, "b": 2}
+
+    def test_waveform_attrs(self):
+        wft = _make_waveform_table()
+        tbl = Table(col_dict={"wf": wft})
+        back = arrow_to_lgdo(lgdo_to_arrow(tbl))
+        assert back["wf"]["t0"].attrs["units"] == "us"
+        assert back["wf"]["dt"].attrs["units"] == "ns"
+
+
+# ============ view_as("arrow") ============
+
+
+class TestViewAs:
+    def test_array_view_as(self):
+        arr = Array(nda=np.array([1, 2, 3]))
+        result = arr.view_as("arrow")
+        assert isinstance(result, pa.Array)
+
+    def test_aoesa_view_as(self):
+        aoesa = ArrayOfEqualSizedArrays(nda=np.arange(12).reshape(3, 4))
+        result = aoesa.view_as("arrow")
+        assert isinstance(result.type, pa.FixedSizeListType)
+
+    def test_vov_view_as(self):
+        vov = VectorOfVectors(
+            flattened_data=np.array([1, 2, 3]),
+            offsets=np.array([0, 2, 3]),
+        )
+        result = vov.view_as("arrow")
+        assert isinstance(result, pa.ListArray)
+
+    def test_table_view_as(self):
+        tbl = Table(col_dict={"x": Array(nda=np.array([1, 2]))})
+        result = tbl.view_as("arrow")
+        assert isinstance(result, pa.Table)
+
+    def test_waveformtable_view_as(self):
+        result = _make_waveform_table().view_as("arrow")
+        assert isinstance(result, pa.StructArray)
+
+
+# ============ Constructor acceptance ============
+
+
+class TestConstructorFromArrow:
+    def test_array_from_pa_array(self):
+        arr = Array(pa.array([1, 2, 3]))
+        assert isinstance(arr, Array)
+        assert_array_equal(arr.nda, [1, 2, 3])
+
+    def test_array_from_pa_chunked_array(self):
+        arr = Array(pa.chunked_array([pa.array([1, 2, 3])]))
+        assert isinstance(arr, Array)
+        assert_array_equal(arr.nda, [1, 2, 3])
+
+    def test_table_from_pa_table(self):
+        tbl = Table(pa.table({"a": [1, 2, 3], "b": [4, 5, 6]}))
+        assert isinstance(tbl, Table)
+        assert list(tbl.keys()) == ["a", "b"]
+        assert_array_equal(tbl["a"].nda, [1, 2, 3])
+
+    def test_vov_from_pa_list_array(self):
+        pa_list = pa.ListArray.from_arrays([0, 2, 5], [10, 20, 30, 40, 50])
+        vov = VectorOfVectors(data=pa_list)
+        assert isinstance(vov, VectorOfVectors)
+        assert_array_equal(vov.flattened_data.nda, [10, 20, 30, 40, 50])
+
+    def test_aoesa_from_pa_fixed_size_list(self):
+        pa_fsl = pa.FixedSizeListArray.from_arrays(pa.array(np.arange(12)), 4)
+        aoesa = ArrayOfEqualSizedArrays(nda=pa_fsl)
+        assert isinstance(aoesa, ArrayOfEqualSizedArrays)
+        assert aoesa.nda.shape == (3, 4)

--- a/tests/types/test_arrow.py
+++ b/tests/types/test_arrow.py
@@ -203,9 +203,7 @@ class TestRoundTrip:
 
 class TestAttrsRoundTrip:
     def test_string_attr(self):
-        tbl = Table(
-            col_dict={"x": Array(nda=np.array([1.0]), attrs={"units": "keV"})}
-        )
+        tbl = Table(col_dict={"x": Array(nda=np.array([1.0]), attrs={"units": "keV"})})
         back = arrow_to_lgdo(lgdo_to_arrow(tbl))
         assert back["x"].attrs["units"] == "keV"
 
@@ -222,18 +220,14 @@ class TestAttrsRoundTrip:
 
     def test_bool_attr(self):
         tbl = Table(
-            col_dict={
-                "x": Array(nda=np.array([1.0]), attrs={"calibrated": True})
-            }
+            col_dict={"x": Array(nda=np.array([1.0]), attrs={"calibrated": True})}
         )
         back = arrow_to_lgdo(lgdo_to_arrow(tbl))
         assert back["x"].attrs["calibrated"] is True
 
     def test_dict_attr(self):
         tbl = Table(
-            col_dict={
-                "x": Array(nda=np.array([1.0]), attrs={"info": {"a": 1, "b": 2}})
-            }
+            col_dict={"x": Array(nda=np.array([1.0]), attrs={"info": {"a": 1, "b": 2}})}
         )
         back = arrow_to_lgdo(lgdo_to_arrow(tbl))
         assert back["x"].attrs["info"] == {"a": 1, "b": 2}

--- a/tests/types/test_arrow.py
+++ b/tests/types/test_arrow.py
@@ -239,6 +239,15 @@ class TestAttrsRoundTrip:
         assert back["wf"]["t0"].attrs["units"] == "us"
         assert back["wf"]["dt"].attrs["units"] == "ns"
 
+    def test_table_level_attrs(self):
+        tbl = Table(
+            col_dict={"x": Array(nda=np.array([1.0]))},
+            attrs={"description": "test table", "version": 42},
+        )
+        back = arrow_to_lgdo(lgdo_to_arrow(tbl))
+        assert back.attrs["description"] == "test table"
+        assert back.attrs["version"] == 42
+
 
 # ============ view_as("arrow") ============
 

--- a/tests/types/test_arrow.py
+++ b/tests/types/test_arrow.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import warnings
 
 import numpy as np
+import pyarrow as pa
 import pytest
 from numpy.testing import assert_array_equal
 
-pa = pytest.importorskip("pyarrow")
-
-from lgdo import Array, ArrayOfEqualSizedArrays, Table, VectorOfVectors  # noqa: E402
-from lgdo.types.arrow import arrow_to_lgdo, lgdo_to_arrow  # noqa: E402
-from lgdo.types.waveformtable import WaveformTable  # noqa: E402
+from lgdo import Array, ArrayOfEqualSizedArrays, Table, VectorOfVectors
+from lgdo.types.arrow import arrow_to_lgdo, lgdo_to_arrow
+from lgdo.types.waveformtable import WaveformTable
 
 # ============ Helpers ============
 


### PR DESCRIPTION
- Add conversion between LGDO types and PyArrow types, integrated into the existing `view_as` API and type constructors
- All conversion logic lives in a single module (`src/lgdo/types/arrow.py`) for centralized maintenance
- Add `pyarrow` as a direct dependency (already transitively required by `awkward` and `pandas`, though)

## Demo

```python
import numpy as np
import pyarrow as pa
from lgdo import Array, ArrayOfEqualSizedArrays, Table, VectorOfVectors
from lgdo.types.waveformtable import WaveformTable

# === LGDO to Arrow ===

tbl = Table(col_dict={
    "energy": Array(nda=np.array([100.5, 200.3, 150.7]), attrs={"units": "keV"}),
    "channel": Array(nda=np.array([0, 1, 2])),
    "hits": VectorOfVectors(
        flattened_data=np.array([1, 2, 3, 4, 5]),
        offsets=np.array([0, 2, 3, 5]),
    ),
    "waveform": WaveformTable(
        t0=Array(nda=np.array([0.0, 0.5, 1.0]), attrs={"units": "us"}),
        dt=Array(nda=np.array([16.0, 16.0, 16.0]), attrs={"units": "ns"}),
        values=ArrayOfEqualSizedArrays(
            nda=np.random.randn(3, 1000).astype(np.float32)
        ),
    ),
})

pa_table = tbl.view_as("arrow")
# pyarrow.Table with columns:
#   energy: double, channel: int64, hits: list<int64>,
#   waveform: struct<t0: double, dt: double, values: fixed_size_list<float>[1000]>

# Individual columns too
pa_arr = tbl["energy"].view_as("arrow")
# pyarrow.lib.DoubleArray [100.5, 200.3, 150.7]

# === Arrow to LGDO ===

# Via constructors -- same interface as pd.DataFrame or ak.Array
tbl2 = Table(pa.table({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0]}))
arr2 = Array(pa.array([1, 2, 3]))

# Via standalone function
from lgdo.types.arrow import arrow_to_lgdo
tbl3 = arrow_to_lgdo(pa_table)

# WaveformTable is reconstructed automatically
assert isinstance(tbl3["waveform"], WaveformTable)

# Attrs survive the round-trip
assert tbl3["energy"].attrs["units"] == "keV"
assert tbl3["waveform"]["t0"].attrs["units"] == "us"
```

## Details

The idea is to find corresponding Arrow type for each LGDO type, which is summarized below.

| LGDO type | Arrow type |
|---|---|
| `Table` | `pa.Table` |
| `WaveformTable` | `pa.StructArray` with fields `{t0, dt, values}` |
| `Array` | `pa.Array` |
| `ArrayOfEqualSizedArrays` | `pa.FixedSizeListArray` |
| `VectorOfVectors` | `pa.ListArray` |

1. All LGDO attrs are round-tripped through Arrow field metadata using JSON serialization, preserving types (int, float, bool, dict, list) losslessly.
2. Numeric arrays use zero-copy views; allocation only occurs for booleans, null-containing columns, or multi-chunk arrays (with a warning).
