### PR TITLE
Bug fix for python 3.14

### DIFF
--- a/src/lgdo/types/array.py
+++ b/src/lgdo/types/array.py
@@ -188,7 +188,7 @@ class Array(LGDOCollection):
 
         if isinstance(new_size, Collection):
             self._size = new_size[0]
-            self._nda.resize(new_size)
+            self._nda.resize(new_size, refcheck=False)
         else:
             self._size = new_size
 

--- a/tests/types/test_waveformtable.py
+++ b/tests/types/test_waveformtable.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import pickle
+
 import numpy as np
 
 import lgdo
 from lgdo import WaveformTable
-
-import pickle
 
 
 def test_init():
@@ -122,6 +122,7 @@ def test_init():
     wft = WaveformTable(10, wf_len=20)
     wft.wf_len = 30
     assert wft.wf_len == 30
+
 
 def test_pickle():
     wft = WaveformTable(size=10, wf_len=1000)

--- a/tests/types/test_waveformtable.py
+++ b/tests/types/test_waveformtable.py
@@ -5,6 +5,8 @@ import numpy as np
 import lgdo
 from lgdo import WaveformTable
 
+import pickle
+
 
 def test_init():
     wft = WaveformTable()  # defaults: size = 1024 and wf_len = 100
@@ -120,3 +122,11 @@ def test_init():
     wft = WaveformTable(10, wf_len=20)
     wft.wf_len = 30
     assert wft.wf_len == 30
+
+def test_pickle():
+    wft = WaveformTable(size=10, wf_len=1000)
+    wft_pickled = pickle.dumps(wft)
+    wft_unpickled = pickle.loads(wft_pickled)
+    assert (wft.t0.nda == wft_unpickled.t0.nda).all()
+    assert (wft.dt.nda == wft_unpickled.dt.nda).all()
+    assert (wft.values.nda == wft_unpickled.values.nda).all()


### PR DESCRIPTION
Use `refcheck=False` in `Array.resize` similarly to `Array.set_capacity`. This fixes a bug caused by change in reference counting in python 3.14, which prevents ArraysOfArrays and WaveformTables from being able to resize inner dimensions (which happens during initialization sometimes!).

Also added test for pickling of WaveformTable